### PR TITLE
Fixing K4A build errors in src/record/internal/matroska_read.cpp abou…

### DIFF
--- a/examples/fastpointcloud/main.cpp
+++ b/examples/fastpointcloud/main.cpp
@@ -146,8 +146,8 @@ int main(int argc, char **argv)
         goto Exit;
     }
 
-    config.depth_mode_id = 3;// K4A_DEPTH_MODE_WFOV_2X2BINNED
-    config.fps_mode_id = 2;// K4A_FRAMES_PER_SECOND_30
+    config.depth_mode_id = 3; // K4A_DEPTH_MODE_WFOV_2X2BINNED
+    config.fps_mode_id = 2;   // K4A_FRAMES_PER_SECOND_30
 
     k4a_calibration_t calibration;
     if (K4A_RESULT_SUCCEEDED !=

--- a/examples/green_screen/main.cpp
+++ b/examples/green_screen/main.cpp
@@ -518,7 +518,7 @@ static k4a_device_configuration_t get_default_config()
     camera_config.color_mode_id = 1; // K4A_COLOR_RESOLUTION_720P
     camera_config.depth_mode_id = 4; // K4A_DEPTH_MODE_WFOV_UNBINNED // No need for depth during calibration
     camera_config.fps_mode_id = 1;   // K4A_FRAMES_PER_SECOND_15 // Don't use all USB bandwidth
-    camera_config.subordinate_delay_off_master_usec = 0;     // Must be zero for master
+    camera_config.subordinate_delay_off_master_usec = 0; // Must be zero for master
     camera_config.synchronized_images_only = true;
     return camera_config;
 }

--- a/examples/k4arecord_custom_track/main.c
+++ b/examples/k4arecord_custom_track/main.c
@@ -73,7 +73,7 @@ int main(int argc, char **argv)
     k4a_device_get_fps_mode(device, 2, &fps_mode_info); // K4A_FRAMES_PER_SECOND_30
 
     k4a_device_configuration_t device_config = K4A_DEVICE_CONFIG_INIT_DISABLE_ALL;
-    device_config.depth_mode_id = depth_mode_info.mode_id; 
+    device_config.depth_mode_id = depth_mode_info.mode_id;
     device_config.fps_mode_id = fps_mode_info.mode_id;
 
     VERIFY(k4a_device_start_cameras(device, &device_config));

--- a/examples/streaming/main.c
+++ b/examples/streaming/main.c
@@ -49,7 +49,7 @@ int main(int argc, char **argv)
 
     k4a_device_configuration_t config = K4A_DEVICE_CONFIG_INIT_DISABLE_ALL;
     config.color_format = K4A_IMAGE_FORMAT_COLOR_MJPG;
-    config.color_mode_id = color_mode_info.mode_id; 
+    config.color_mode_id = color_mode_info.mode_id;
     config.depth_mode_id = depth_mode_info.mode_id;
     config.fps_mode_id = fps_mode_info.mode_id;
 

--- a/examples/transformation/main.cpp
+++ b/examples/transformation/main.cpp
@@ -146,9 +146,9 @@ static int capture(std::string output_dir, uint8_t deviceId = K4A_DEVICE_DEFAULT
     }
 
     config.color_format = K4A_IMAGE_FORMAT_COLOR_BGRA32;
-    config.color_mode_id = 1; // K4A_COLOR_RESOLUTION_720P
-    config.depth_mode_id = 2; // K4A_DEPTH_MODE_NFOV_UNBINNED
-    config.fps_mode_id = 2; // K4A_FRAMES_PER_SECOND_30
+    config.color_mode_id = 1;               // K4A_COLOR_RESOLUTION_720P
+    config.depth_mode_id = 2;               // K4A_DEPTH_MODE_NFOV_UNBINNED
+    config.fps_mode_id = 2;                 // K4A_FRAMES_PER_SECOND_30
     config.synchronized_images_only = true; // ensures that depth and color images are both available in the capture
 
     k4a_calibration_t calibration;

--- a/examples/undistort/main.cpp
+++ b/examples/undistort/main.cpp
@@ -377,8 +377,8 @@ int main(int argc, char **argv)
         goto Exit;
     }
 
-    config.depth_mode_id = 3;// K4A_DEPTH_MODE_WFOV_2X2BINNED
-    config.fps_mode_id = 2;// K4A_FRAMES_PER_SECOND_30
+    config.depth_mode_id = 3; // K4A_DEPTH_MODE_WFOV_2X2BINNED
+    config.fps_mode_id = 2;   // K4A_FRAMES_PER_SECOND_30
 
     k4a_calibration_t calibration;
     if (K4A_RESULT_SUCCEEDED !=

--- a/examples/viewer/opengl/main.cpp
+++ b/examples/viewer/opengl/main.cpp
@@ -106,8 +106,7 @@ int main()
                 //
                 ColorizeDepthImage(depthImage,
                                    K4ADepthPixelColorizer::ColorizeBlueToRed,
-                                   { (uint16_t)depth_mode_info.min_range,
-                                     (uint16_t)depth_mode_info.max_range },
+                                   { (uint16_t)depth_mode_info.min_range, (uint16_t)depth_mode_info.max_range },
                                    &depthTextureBuffer);
                 depthTexture.Update(&depthTextureBuffer[0]);
 

--- a/include/k4a/k4a.h
+++ b/include/k4a/k4a.h
@@ -2291,7 +2291,6 @@ K4A_EXPORT k4a_result_t k4a_device_get_fps_mode(k4a_device_t device_handle,
                                                 int mode_index,
                                                 k4a_fps_mode_info_t *mode_info);
 
-
 /**
  * @}
  */

--- a/include/k4a/k4a.hpp
+++ b/include/k4a/k4a.hpp
@@ -764,17 +764,12 @@ struct calibration : public k4a_calibration_t
      *
      * \sa k4a_calibration_get_from_raw
      */
-    static calibration get_from_raw(char *raw_calibration,
-                                    size_t raw_calibration_size,
-                                    uint32_t depth_mode_id,
-                                    uint32_t color_mode_id)
+    static calibration
+    get_from_raw(char *raw_calibration, size_t raw_calibration_size, uint32_t depth_mode_id, uint32_t color_mode_id)
     {
         calibration calib;
-        k4a_result_t result = k4a_calibration_get_from_raw(raw_calibration,
-                                                           raw_calibration_size,
-                                                           depth_mode_id,
-                                                           color_mode_id,
-                                                           &calib);
+        k4a_result_t result =
+            k4a_calibration_get_from_raw(raw_calibration, raw_calibration_size, depth_mode_id, color_mode_id, &calib);
 
         if (K4A_RESULT_SUCCEEDED != result)
         {
@@ -788,10 +783,8 @@ struct calibration : public k4a_calibration_t
      *
      * \sa k4a_calibration_get_from_raw
      */
-    static calibration get_from_raw(uint8_t *raw_calibration,
-                                    size_t raw_calibration_size,
-                                    uint32_t depth_mode_id,
-                                    uint32_t color_mode_id)
+    static calibration
+    get_from_raw(uint8_t *raw_calibration, size_t raw_calibration_size, uint32_t depth_mode_id, uint32_t color_mode_id)
     {
         return get_from_raw(reinterpret_cast<char *>(raw_calibration),
                             raw_calibration_size,
@@ -1449,7 +1442,6 @@ public:
         return k4a_device_get_installed_count();
     }
 
-
     // TODO: add comments
     k4a_device_info_t get_info()
     {
@@ -1457,8 +1449,8 @@ public:
         k4a_device_get_info(m_handle, &info);
 
         return info;
-    } 
-    
+    }
+
     // TODO: add comments
     std::vector<k4a_color_mode_info_t> get_color_modes()
     {
@@ -1480,8 +1472,8 @@ public:
         }
 
         return modes;
-    }    
-    
+    }
+
     // TODO: add comments
     k4a_color_mode_info_t get_color_mode(int color_mode_id)
     {
@@ -1501,8 +1493,8 @@ public:
         }
 
         return mode;
-    } 
-    
+    }
+
     // TODO: add comments
     std::vector<k4a_depth_mode_info_t> get_depth_modes()
     {
@@ -1522,7 +1514,7 @@ public:
                 }
             }
         }
-        
+
         return modes;
     }
 
@@ -1545,7 +1537,7 @@ public:
         }
 
         return mode;
-    } 
+    }
 
     // TODO: add comments
     std::vector<k4a_fps_mode_info_t> get_fps_modes()
@@ -1589,10 +1581,10 @@ public:
         }
 
         return mode;
-    } 
+    }
 
     // TODO: add comments
-    int get_common_factor(int width, int height) 
+    int get_common_factor(int width, int height)
     {
         return (height == 0) ? width : get_common_factor(height, width % height);
     }

--- a/include/k4a/k4atypes.h
+++ b/include/k4a/k4atypes.h
@@ -195,11 +195,10 @@ K4A_DECLARE_HANDLE(k4a_image_t);
 K4A_DECLARE_HANDLE(k4a_transformation_t);
 
 // TODO: comment
-#define K4A_INIT_STRUCT(T, S) \
-    T S{}; \
-    S.struct_size = sizeof(T); \
+#define K4A_INIT_STRUCT(T, S)                                                                                          \
+    T S{};                                                                                                             \
+    S.struct_size = sizeof(T);                                                                                         \
     S.struct_version = K4A_ABI_VERSION;
-
 
 // TODO: comment
 #define K4A_ABI_VERSION 1
@@ -1254,9 +1253,8 @@ typedef struct _k4a_imu_sample_t
  * </requirements>
  * \endxmlonly
  */
-static const k4a_device_configuration_t K4A_DEVICE_CONFIG_INIT_DISABLE_ALL = {
-    K4A_IMAGE_FORMAT_COLOR_MJPG, 0, 0, 2, false, 0, K4A_WIRED_SYNC_MODE_STANDALONE, 0, false
-};
+static const k4a_device_configuration_t K4A_DEVICE_CONFIG_INIT_DISABLE_ALL =
+    { K4A_IMAGE_FORMAT_COLOR_MJPG, 0, 0, 2, false, 0, K4A_WIRED_SYNC_MODE_STANDALONE, 0, false };
 
 /**
  * @}

--- a/include/k4ainternal/matroska_read.h
+++ b/include/k4ainternal/matroska_read.h
@@ -17,10 +17,8 @@
 namespace k4arecord
 {
 // The depth mode string for legacy recordings
-static const std::pair<k4a_depth_mode_t, std::string> legacy_depth_modes[] = {
-    { K4A_DEPTH_MODE_NFOV_2X2BINNED, "NFOV_2x2BINNED" },
-    { K4A_DEPTH_MODE_WFOV_2X2BINNED, "WFOV_2x2BINNED" }
-};
+static const std::pair<k4a_depth_mode_t, std::string> legacy_depth_modes[] =
+    { { K4A_DEPTH_MODE_NFOV_2X2BINNED, "NFOV_2x2BINNED" }, { K4A_DEPTH_MODE_WFOV_2X2BINNED, "WFOV_2x2BINNED" } };
 
 typedef struct _cluster_info_t
 {

--- a/src/dewrapper/dewrapper.c
+++ b/src/dewrapper/dewrapper.c
@@ -127,8 +127,10 @@ static k4a_result_t depth_engine_start_helper(dewrapper_context_t *dewrapper,
                                               int *depth_engine_max_compute_time_ms,
                                               size_t *depth_engine_output_buffer_size)
 {
-    RETURN_VALUE_IF_ARG(K4A_RESULT_FAILED, fps_mode_id < K4A_FRAMES_PER_SECOND_5 || fps_mode_id > K4A_FRAMES_PER_SECOND_30);
-    RETURN_VALUE_IF_ARG(K4A_RESULT_FAILED, depth_mode_id <= K4A_DEPTH_MODE_OFF || depth_mode_id > K4A_DEPTH_MODE_PASSIVE_IR);
+    RETURN_VALUE_IF_ARG(K4A_RESULT_FAILED,
+                        fps_mode_id < K4A_FRAMES_PER_SECOND_5 || fps_mode_id > K4A_FRAMES_PER_SECOND_30);
+    RETURN_VALUE_IF_ARG(K4A_RESULT_FAILED,
+                        depth_mode_id <= K4A_DEPTH_MODE_OFF || depth_mode_id > K4A_DEPTH_MODE_PASSIVE_IR);
     k4a_result_t result = K4A_RESULT_SUCCEEDED;
 
     assert(dewrapper->depth_engine == NULL);
@@ -587,7 +589,7 @@ void dewrapper_stop(dewrapper_t dewrapper_handle)
         (void)K4A_RESULT_FROM_BOOL(tresult == THREADAPI_OK); // Trace the issue, but we don't return a failure
 
         // TODO: watch out for whatever was supposed to happen by having set fps = -1
-        dewrapper->fps_mode_id = 2; // 
+        dewrapper->fps_mode_id = 2;   //
         dewrapper->depth_mode_id = 0; // K4A_DEPTH_MODE_OFF
     }
 

--- a/src/record/internal/matroska_read.cpp
+++ b/src/record/internal/matroska_read.cpp
@@ -443,7 +443,7 @@ k4a_result_t parse_recording_config(k4a_playback_context_t *context)
         frame_period_ns = context->color_track->frame_period_ns;
 
         RETURN_IF_ERROR(read_bitmap_info_header(context->color_track));
-        
+
         for (size_t i = 0; i < arraysize(color_resolutions); i++)
         {
             uint32_t width, height;
@@ -638,15 +638,13 @@ k4a_result_t parse_recording_config(k4a_playback_context_t *context)
         fps_mode_id = K4A_FRAMES_PER_SECOND_30;
     }
 
-
-    
     // TODO: comment
 
     KaxTag *device_info_tag = get_tag(context, "K4A_DEVICE_INFO");
     KaxTag *color_mode_info_tag = get_tag(context, "K4A_COLOR_MODE_INFO");
     KaxTag *depth_mode_info_tag = get_tag(context, "K4A_DEPTH_MODE_INFO");
     KaxTag *fps_mode_info_tag = get_tag(context, "K4A_FPS_MODE_INFO");
-    
+
     k4a_device_info_t device_info = { sizeof(k4a_device_info_t), K4A_ABI_VERSION, { 0 } };
     k4a_color_mode_info_t color_mode_info = { sizeof(k4a_color_mode_info_t), K4A_ABI_VERSION, { 0 } };
     k4a_depth_mode_info_t depth_mode_info = { sizeof(k4a_depth_mode_info_t), K4A_ABI_VERSION, { 0 } };
@@ -692,7 +690,7 @@ k4a_result_t parse_recording_config(k4a_playback_context_t *context)
                 {
                     device_info_result = K4A_RESULT_FAILED;
                 }
-                
+
                 const cJSON *device_info_json_vendor_id = cJSON_GetObjectItem(device_info_json, "vendor_id");
                 if (cJSON_IsNumber(device_info_json_vendor_id) && device_info_json_vendor_id->valuedouble != NULL)
                 {
@@ -702,7 +700,6 @@ k4a_result_t parse_recording_config(k4a_playback_context_t *context)
                 {
                     device_info_result = K4A_RESULT_FAILED;
                 }
-
             }
             else
             {
@@ -715,7 +712,7 @@ k4a_result_t parse_recording_config(k4a_playback_context_t *context)
             device_info_result = K4A_RESULT_FAILED;
         }
     }
-    
+
     if (!K4A_SUCCEEDED(device_info_result))
     {
         device_info.device_id = K4A_DEPTH_PID;
@@ -724,7 +721,7 @@ k4a_result_t parse_recording_config(k4a_playback_context_t *context)
     }
 
     context->record_config.device_info = device_info;
-    
+
     // color
     if (hasColorDevice && color_mode_info_tag != NULL)
     {
@@ -766,18 +763,23 @@ k4a_result_t parse_recording_config(k4a_playback_context_t *context)
                     color_mode_info_result = K4A_RESULT_FAILED;
                 }
 
-                const cJSON *color_mode_info_json_native_format = cJSON_GetObjectItem(color_mode_info_json, "native_format");
-                if (cJSON_IsNumber(color_mode_info_json_native_format) && color_mode_info_json_native_format->valuedouble != NULL)
+                const cJSON *color_mode_info_json_native_format = cJSON_GetObjectItem(color_mode_info_json,
+                                                                                      "native_format");
+                if (cJSON_IsNumber(color_mode_info_json_native_format) &&
+                    color_mode_info_json_native_format->valuedouble != NULL)
                 {
-                    color_mode_info.native_format = (k4a_image_format_t)color_mode_info_json_native_format->valuedouble;
+                    color_mode_info.native_format = (k4a_image_format_t)(
+                                                        int)color_mode_info_json_native_format->valuedouble;
                 }
                 else
                 {
                     color_mode_info_result = K4A_RESULT_FAILED;
                 }
 
-                const cJSON *color_mode_info_json_horizontal_fov = cJSON_GetObjectItem(color_mode_info_json, "horizontal_fov");
-                if (cJSON_IsNumber(color_mode_info_json_horizontal_fov) && color_mode_info_json_horizontal_fov->valuedouble != NULL)
+                const cJSON *color_mode_info_json_horizontal_fov = cJSON_GetObjectItem(color_mode_info_json,
+                                                                                       "horizontal_fov");
+                if (cJSON_IsNumber(color_mode_info_json_horizontal_fov) &&
+                    color_mode_info_json_horizontal_fov->valuedouble != NULL)
                 {
                     color_mode_info.horizontal_fov = (float)color_mode_info_json_horizontal_fov->valuedouble;
                 }
@@ -786,8 +788,10 @@ k4a_result_t parse_recording_config(k4a_playback_context_t *context)
                     color_mode_info_result = K4A_RESULT_FAILED;
                 }
 
-                const cJSON *color_mode_info_json_vertical_fov = cJSON_GetObjectItem(color_mode_info_json, "vertical_fov");
-                if (cJSON_IsNumber(color_mode_info_json_vertical_fov) && color_mode_info_json_vertical_fov->valuedouble != NULL)
+                const cJSON *color_mode_info_json_vertical_fov = cJSON_GetObjectItem(color_mode_info_json,
+                                                                                     "vertical_fov");
+                if (cJSON_IsNumber(color_mode_info_json_vertical_fov) &&
+                    color_mode_info_json_vertical_fov->valuedouble != NULL)
                 {
                     color_mode_info.vertical_fov = (float)color_mode_info_json_vertical_fov->valuedouble;
                 }
@@ -832,7 +836,7 @@ k4a_result_t parse_recording_config(k4a_playback_context_t *context)
     {
         color_mode_info_result = K4A_RESULT_FAILED;
     }
-    
+
     if (!K4A_SUCCEEDED(color_mode_info_result))
     {
         struct _recording_color_modes
@@ -844,13 +848,14 @@ k4a_result_t parse_recording_config(k4a_playback_context_t *context)
             float vertical_fov;
             int min_fps;
             int max_fps;
-        } recording_color_modes[] = { { 0, 0, K4A_IMAGE_FORMAT_COLOR_MJPG, 0, 0, 0, 0 }, // color mode will be turned off
-                                        { 1280, 720, K4A_IMAGE_FORMAT_COLOR_MJPG, 90.0f, 59.0f, 5, 30 },
-                                        { 1920, 1080, K4A_IMAGE_FORMAT_COLOR_MJPG, 90.0f, 59.0f, 5, 30 },
-                                        { 2560, 1440, K4A_IMAGE_FORMAT_COLOR_MJPG, 90.0f, 59.0f, 5, 30 },
-                                        { 2048, 1536, K4A_IMAGE_FORMAT_COLOR_MJPG, 90.0f, 74.3f, 5, 30 },
-                                        { 3840, 2160, K4A_IMAGE_FORMAT_COLOR_MJPG, 90.0f, 59.0f, 5, 30 },
-                                        { 4096, 3072, K4A_IMAGE_FORMAT_COLOR_MJPG, 90.0f, 74.3f, 5, 30 } };
+        } recording_color_modes[] = { { 0, 0, K4A_IMAGE_FORMAT_COLOR_MJPG, 0, 0, 0, 0 }, // color mode will be turned
+                                                                                         // off
+                                      { 1280, 720, K4A_IMAGE_FORMAT_COLOR_MJPG, 90.0f, 59.0f, 5, 30 },
+                                      { 1920, 1080, K4A_IMAGE_FORMAT_COLOR_MJPG, 90.0f, 59.0f, 5, 30 },
+                                      { 2560, 1440, K4A_IMAGE_FORMAT_COLOR_MJPG, 90.0f, 59.0f, 5, 30 },
+                                      { 2048, 1536, K4A_IMAGE_FORMAT_COLOR_MJPG, 90.0f, 74.3f, 5, 30 },
+                                      { 3840, 2160, K4A_IMAGE_FORMAT_COLOR_MJPG, 90.0f, 59.0f, 5, 30 },
+                                      { 4096, 3072, K4A_IMAGE_FORMAT_COLOR_MJPG, 90.0f, 74.3f, 5, 30 } };
 
         color_mode_info.mode_id = color_mode_id;
         color_mode_info.width = recording_color_modes[color_mode_id].width;
@@ -884,7 +889,8 @@ k4a_result_t parse_recording_config(k4a_playback_context_t *context)
                     depth_mode_info_result = K4A_RESULT_FAILED;
                 }
 
-                const cJSON *depth_mode_info_json_passive_ir_only = cJSON_GetObjectItem(depth_mode_info_json, "passive_ir_only");
+                const cJSON *depth_mode_info_json_passive_ir_only = cJSON_GetObjectItem(depth_mode_info_json,
+                                                                                        "passive_ir_only");
                 if (cJSON_IsBool(depth_mode_info_json_passive_ir_only) && depth_mode_info_json_passive_ir_only != NULL)
                 {
                     depth_mode_info.passive_ir_only = cJSON_IsTrue(depth_mode_info_json_passive_ir_only) ? true : false;
@@ -895,7 +901,7 @@ k4a_result_t parse_recording_config(k4a_playback_context_t *context)
                 }
 
                 const cJSON *depth_mode_info_json_width = cJSON_GetObjectItem(depth_mode_info_json, "width");
-                if (cJSON_IsNumber(depth_mode_info_json_width) && depth_mode_info_json_width->valuedouble  != NULL)
+                if (cJSON_IsNumber(depth_mode_info_json_width) && depth_mode_info_json_width->valuedouble != NULL)
                 {
                     depth_mode_info.width = (uint32_t)depth_mode_info_json_width->valuedouble;
                 }
@@ -914,18 +920,23 @@ k4a_result_t parse_recording_config(k4a_playback_context_t *context)
                     depth_mode_info_result = K4A_RESULT_FAILED;
                 }
 
-                const cJSON *depth_mode_info_json_native_format = cJSON_GetObjectItem(depth_mode_info_json, "native_format");
-                if (cJSON_IsNumber(depth_mode_info_json_native_format) && depth_mode_info_json_native_format->valuedouble != NULL)
+                const cJSON *depth_mode_info_json_native_format = cJSON_GetObjectItem(depth_mode_info_json,
+                                                                                      "native_format");
+                if (cJSON_IsNumber(depth_mode_info_json_native_format) &&
+                    depth_mode_info_json_native_format->valuedouble != NULL)
                 {
-                    depth_mode_info.native_format = (k4a_image_format_t)depth_mode_info_json_native_format->valuedouble;
+                    depth_mode_info.native_format = (k4a_image_format_t)(
+                                                        int)depth_mode_info_json_native_format->valuedouble;
                 }
                 else
                 {
                     depth_mode_info_result = K4A_RESULT_FAILED;
                 }
 
-                const cJSON *depth_mode_info_json_horizontal_fov = cJSON_GetObjectItem(depth_mode_info_json, "horizontal_fov");
-                if (cJSON_IsNumber(depth_mode_info_json_horizontal_fov) && depth_mode_info_json_horizontal_fov->valuedouble != NULL)
+                const cJSON *depth_mode_info_json_horizontal_fov = cJSON_GetObjectItem(depth_mode_info_json,
+                                                                                       "horizontal_fov");
+                if (cJSON_IsNumber(depth_mode_info_json_horizontal_fov) &&
+                    depth_mode_info_json_horizontal_fov->valuedouble != NULL)
                 {
                     depth_mode_info.horizontal_fov = (float)depth_mode_info_json_horizontal_fov->valuedouble;
                 }
@@ -934,8 +945,10 @@ k4a_result_t parse_recording_config(k4a_playback_context_t *context)
                     depth_mode_info_result = K4A_RESULT_FAILED;
                 }
 
-                const cJSON *depth_mode_info_json_vertical_fov = cJSON_GetObjectItem(depth_mode_info_json, "vertical_fov");
-                if (cJSON_IsNumber(depth_mode_info_json_vertical_fov) && depth_mode_info_json_vertical_fov->valuedouble != NULL)
+                const cJSON *depth_mode_info_json_vertical_fov = cJSON_GetObjectItem(depth_mode_info_json,
+                                                                                     "vertical_fov");
+                if (cJSON_IsNumber(depth_mode_info_json_vertical_fov) &&
+                    depth_mode_info_json_vertical_fov->valuedouble != NULL)
                 {
                     depth_mode_info.vertical_fov = (float)depth_mode_info_json_vertical_fov->valuedouble;
                 }
@@ -965,7 +978,8 @@ k4a_result_t parse_recording_config(k4a_playback_context_t *context)
                 }
 
                 const cJSON *depth_mode_info_json_min_range = cJSON_GetObjectItem(depth_mode_info_json, "min_range");
-                if (cJSON_IsNumber(depth_mode_info_json_min_range) && depth_mode_info_json_min_range->valuedouble != NULL)
+                if (cJSON_IsNumber(depth_mode_info_json_min_range) &&
+                    depth_mode_info_json_min_range->valuedouble != NULL)
                 {
                     depth_mode_info.min_range = (int)depth_mode_info_json_min_range->valuedouble;
                 }
@@ -975,7 +989,8 @@ k4a_result_t parse_recording_config(k4a_playback_context_t *context)
                 }
 
                 const cJSON *depth_mode_info_json_max_range = cJSON_GetObjectItem(depth_mode_info_json, "max_range");
-                if (cJSON_IsNumber(depth_mode_info_json_max_range) && depth_mode_info_json_max_range->valuedouble != NULL)
+                if (cJSON_IsNumber(depth_mode_info_json_max_range) &&
+                    depth_mode_info_json_max_range->valuedouble != NULL)
                 {
                     depth_mode_info.max_range = (int)depth_mode_info_json_max_range->valuedouble;
                 }
@@ -1000,7 +1015,7 @@ k4a_result_t parse_recording_config(k4a_playback_context_t *context)
     {
         depth_mode_info_result = K4A_RESULT_FAILED;
     }
-    
+
     if (!K4A_SUCCEEDED(depth_mode_info_result))
     {
         struct _recording_depth_modes
@@ -1015,14 +1030,14 @@ k4a_result_t parse_recording_config(k4a_playback_context_t *context)
             int max_fps;
             int min_range;
             int max_range;
-        } recording_depth_modes[] = {
-            { false, 0, 0, K4A_IMAGE_FORMAT_DEPTH16, 0.0f, 0.0f, 0, 0, 0, 0 }, // depth mode will be turned off
-            { false, 320, 288, K4A_IMAGE_FORMAT_DEPTH16, 75.0f, 65.0f, 5, 30, 500, 5800 },
-            { false, 640, 576, K4A_IMAGE_FORMAT_DEPTH16, 75.0f, 65.0f, 5, 30, 500, 4000 },
-            { false, 512, 512, K4A_IMAGE_FORMAT_DEPTH16, 120.0f, 120.0f, 5, 30, 250, 3000 },
-            { false, 1024, 1024, K4A_IMAGE_FORMAT_DEPTH16, 120.0f, 120.0f, 5, 30, 250, 2500 },
-            { true, 1024, 1024, K4A_IMAGE_FORMAT_DEPTH16, 120.0f, 120.0f, 5, 30, 0, 100 }
-        };
+        } recording_depth_modes[] = { { false, 0, 0, K4A_IMAGE_FORMAT_DEPTH16, 0.0f, 0.0f, 0, 0, 0, 0 }, // depth mode
+                                                                                                         // will be
+                                                                                                         // turned off
+                                      { false, 320, 288, K4A_IMAGE_FORMAT_DEPTH16, 75.0f, 65.0f, 5, 30, 500, 5800 },
+                                      { false, 640, 576, K4A_IMAGE_FORMAT_DEPTH16, 75.0f, 65.0f, 5, 30, 500, 4000 },
+                                      { false, 512, 512, K4A_IMAGE_FORMAT_DEPTH16, 120.0f, 120.0f, 5, 30, 250, 3000 },
+                                      { false, 1024, 1024, K4A_IMAGE_FORMAT_DEPTH16, 120.0f, 120.0f, 5, 30, 250, 2500 },
+                                      { true, 1024, 1024, K4A_IMAGE_FORMAT_DEPTH16, 120.0f, 120.0f, 5, 30, 0, 100 } };
 
         depth_mode_info.mode_id = depth_mode_id;
         depth_mode_info.passive_ir_only = recording_depth_modes[depth_mode_id].passive_ir_only;
@@ -1036,7 +1051,7 @@ k4a_result_t parse_recording_config(k4a_playback_context_t *context)
         depth_mode_info.min_range = recording_depth_modes[depth_mode_id].min_range;
         depth_mode_info.max_range = recording_depth_modes[depth_mode_id].max_range;
     }
-               
+
     context->record_config.depth_mode_info = depth_mode_info;
 
     // fps
@@ -1085,7 +1100,7 @@ k4a_result_t parse_recording_config(k4a_playback_context_t *context)
     {
         fps_mode_info_result = K4A_RESULT_FAILED;
     }
- 
+
     if (!K4A_SUCCEEDED(fps_mode_info_result))
     {
         struct _recording_fps_modes
@@ -1098,8 +1113,6 @@ k4a_result_t parse_recording_config(k4a_playback_context_t *context)
     }
 
     context->record_config.fps_mode_info = fps_mode_info;
-
-
 
     // Read depth_delay_off_color_usec and set offsets for each builtin track accordingly.
     KaxTag *depth_delay_tag = get_tag(context, "K4A_DEPTH_DELAY_NS");

--- a/src/record/sdk/record.cpp
+++ b/src/record/sdk/record.cpp
@@ -63,7 +63,9 @@ k4a_result_t k4a_record_create(const char *path,
     uint32_t color_height = 0;
     if (K4A_SUCCEEDED(result) && device_config.color_mode_id != K4A_COLOR_RESOLUTION_OFF)
     {
-        if (!k4a_convert_resolution_to_width_height((k4a_color_resolution_t)device_config.color_mode_id, &color_width, &color_height))
+        if (!k4a_convert_resolution_to_width_height((k4a_color_resolution_t)device_config.color_mode_id,
+                                                    &color_width,
+                                                    &color_height))
         {
             LOG_ERROR("Unsupported color_resolution specified in recording: %d", device_config.color_mode_id);
             result = K4A_RESULT_FAILED;
@@ -151,7 +153,8 @@ k4a_result_t k4a_record_create(const char *path,
     if (K4A_SUCCEEDED(result) && device_config.color_mode_id != K4A_COLOR_RESOLUTION_OFF)
     {
         BITMAPINFOHEADER codec_info = {};
-        result = TRACE_CALL(populate_bitmap_info_header(&codec_info, color_width, color_height, device_config.color_format));
+        result = TRACE_CALL(
+            populate_bitmap_info_header(&codec_info, color_width, color_height, device_config.color_format));
 
         context->color_track = add_track(context,
                                          K4A_TRACK_NAME_COLOR,
@@ -303,11 +306,13 @@ k4a_result_t k4a_record_create(const char *path,
     {
         // Add calibration.json to the recording
         size_t calibration_size = 0;
-        k4a_buffer_result_t buffer_result = TRACE_BUFFER_CALL(k4a_device_get_raw_calibration(device, NULL, &calibration_size));
+        k4a_buffer_result_t buffer_result = TRACE_BUFFER_CALL(
+            k4a_device_get_raw_calibration(device, NULL, &calibration_size));
         if (buffer_result == K4A_BUFFER_RESULT_TOO_SMALL)
         {
             std::vector<uint8_t> calibration_buffer = std::vector<uint8_t>(calibration_size);
-            buffer_result = TRACE_BUFFER_CALL(k4a_device_get_raw_calibration(device, calibration_buffer.data(), &calibration_size));
+            buffer_result = TRACE_BUFFER_CALL(
+                k4a_device_get_raw_calibration(device, calibration_buffer.data(), &calibration_size));
             if (buffer_result == K4A_BUFFER_RESULT_SUCCEEDED)
             {
                 // Remove the null-terminated byte from the file before writing it.
@@ -337,10 +342,9 @@ k4a_result_t k4a_record_create(const char *path,
         }
     }
 
-    
     // TODO: remove after finished testing
     // k4arecorder -l 10 -c 1080p -d NFOV_2X2BINNED -r 30 "D:\Neal Analytics\Microsoft\Kinect Recordings\output.mkv"
-    
+
     // TODO: comment
     bool hasColorDevice = false;
     bool hasDepthDevice = false;
@@ -420,7 +424,9 @@ k4a_result_t k4a_record_create(const char *path,
 
         k4a_color_mode_info_t color_mode_info = { sizeof(k4a_color_mode_info_t), K4A_ABI_VERSION, { 0 } };
 
-        k4a_result_t color_mode_result = k4a_device_get_color_mode(device, device_config.color_mode_id, &color_mode_info);
+        k4a_result_t color_mode_result = k4a_device_get_color_mode(device,
+                                                                   device_config.color_mode_id,
+                                                                   &color_mode_info);
 
         if (K4A_SUCCEEDED(color_mode_result))
         {
@@ -439,7 +445,6 @@ k4a_result_t k4a_record_create(const char *path,
                 }
             }
 
-            
             if (K4A_SUCCEEDED(result))
             {
                 if (cJSON_AddNumberToObject(color_mode_info_json, "height", color_mode_info.height) == NULL)
@@ -450,7 +455,8 @@ k4a_result_t k4a_record_create(const char *path,
 
             if (K4A_SUCCEEDED(result))
             {
-                if (cJSON_AddNumberToObject(color_mode_info_json, "native_format", color_mode_info.native_format) == NULL)
+                if (cJSON_AddNumberToObject(color_mode_info_json, "native_format", color_mode_info.native_format) ==
+                    NULL)
                 {
                     result = K4A_RESULT_FAILED;
                 }
@@ -458,7 +464,8 @@ k4a_result_t k4a_record_create(const char *path,
 
             if (K4A_SUCCEEDED(result))
             {
-                if (cJSON_AddNumberToObject(color_mode_info_json, "horizontal_fov", color_mode_info.horizontal_fov) == NULL)
+                if (cJSON_AddNumberToObject(color_mode_info_json, "horizontal_fov", color_mode_info.horizontal_fov) ==
+                    NULL)
                 {
                     result = K4A_RESULT_FAILED;
                 }
@@ -517,13 +524,14 @@ k4a_result_t k4a_record_create(const char *path,
 
         k4a_depth_mode_info_t depth_mode_info = { sizeof(k4a_depth_mode_info_t), K4A_ABI_VERSION, { 0 } };
 
-        k4a_result_t depth_mode_result = k4a_device_get_depth_mode(device, device_config.depth_mode_id, &depth_mode_info);
+        k4a_result_t depth_mode_result = k4a_device_get_depth_mode(device,
+                                                                   device_config.depth_mode_id,
+                                                                   &depth_mode_info);
         if (K4A_SUCCEEDED(depth_mode_result))
         {
 
             cJSON *depth_mode_info_json = cJSON_CreateObject();
 
-            
             if (K4A_SUCCEEDED(result))
             {
                 if (cJSON_AddNumberToObject(depth_mode_info_json, "mode_id", depth_mode_info.mode_id) == NULL)
@@ -531,15 +539,16 @@ k4a_result_t k4a_record_create(const char *path,
                     result = K4A_RESULT_FAILED;
                 }
             }
-            
+
             if (K4A_SUCCEEDED(result))
             {
-                if (cJSON_AddBoolToObject(depth_mode_info_json, "passive_ir_only", depth_mode_info.passive_ir_only) == NULL)
+                if (cJSON_AddBoolToObject(depth_mode_info_json, "passive_ir_only", depth_mode_info.passive_ir_only) ==
+                    NULL)
                 {
                     result = K4A_RESULT_FAILED;
                 }
             }
-            
+
             if (K4A_SUCCEEDED(result))
             {
                 if (cJSON_AddNumberToObject(depth_mode_info_json, "width", depth_mode_info.width) == NULL)
@@ -547,7 +556,7 @@ k4a_result_t k4a_record_create(const char *path,
                     result = K4A_RESULT_FAILED;
                 }
             }
-            
+
             if (K4A_SUCCEEDED(result))
             {
                 if (cJSON_AddNumberToObject(depth_mode_info_json, "height", depth_mode_info.height) == NULL)
@@ -555,23 +564,25 @@ k4a_result_t k4a_record_create(const char *path,
                     result = K4A_RESULT_FAILED;
                 }
             }
-            
+
             if (K4A_SUCCEEDED(result))
             {
-                if (cJSON_AddNumberToObject(depth_mode_info_json, "native_format", depth_mode_info.native_format) == NULL)
+                if (cJSON_AddNumberToObject(depth_mode_info_json, "native_format", depth_mode_info.native_format) ==
+                    NULL)
                 {
                     result = K4A_RESULT_FAILED;
                 }
             }
-            
+
             if (K4A_SUCCEEDED(result))
             {
-                if (cJSON_AddNumberToObject(depth_mode_info_json, "horizontal_fov", depth_mode_info.horizontal_fov) == NULL)
+                if (cJSON_AddNumberToObject(depth_mode_info_json, "horizontal_fov", depth_mode_info.horizontal_fov) ==
+                    NULL)
                 {
                     result = K4A_RESULT_FAILED;
                 }
             }
-            
+
             if (K4A_SUCCEEDED(result))
             {
                 if (cJSON_AddNumberToObject(depth_mode_info_json, "vertical_fov", depth_mode_info.vertical_fov) == NULL)
@@ -579,7 +590,7 @@ k4a_result_t k4a_record_create(const char *path,
                     result = K4A_RESULT_FAILED;
                 }
             }
-            
+
             if (K4A_SUCCEEDED(result))
             {
                 if (cJSON_AddNumberToObject(depth_mode_info_json, "min_fps", depth_mode_info.min_fps) == NULL)
@@ -587,7 +598,7 @@ k4a_result_t k4a_record_create(const char *path,
                     result = K4A_RESULT_FAILED;
                 }
             }
-            
+
             if (K4A_SUCCEEDED(result))
             {
                 if (cJSON_AddNumberToObject(depth_mode_info_json, "max_fps", depth_mode_info.max_fps) == NULL)
@@ -595,7 +606,7 @@ k4a_result_t k4a_record_create(const char *path,
                     result = K4A_RESULT_FAILED;
                 }
             }
-            
+
             if (K4A_SUCCEEDED(result))
             {
                 if (cJSON_AddNumberToObject(depth_mode_info_json, "min_range", depth_mode_info.min_range) == NULL)
@@ -611,7 +622,7 @@ k4a_result_t k4a_record_create(const char *path,
                     result = K4A_RESULT_FAILED;
                 }
             }
-            
+
             if (K4A_SUCCEEDED(result))
             {
                 depth_mode_info_str = cJSON_Print(depth_mode_info_json);
@@ -654,7 +665,7 @@ k4a_result_t k4a_record_create(const char *path,
                     result = K4A_RESULT_FAILED;
                 }
             }
-            
+
             if (K4A_SUCCEEDED(result))
             {
                 if (cJSON_AddNumberToObject(fps_mode_info_json, "fps", fps_mode_info.fps) == NULL)
@@ -662,7 +673,7 @@ k4a_result_t k4a_record_create(const char *path,
                     result = K4A_RESULT_FAILED;
                 }
             }
-            
+
             if (K4A_SUCCEEDED(result))
             {
                 fps_mode_info_str = cJSON_Print(fps_mode_info_json);

--- a/src/sdk/k4a.c
+++ b/src/sdk/k4a.c
@@ -596,8 +596,7 @@ static k4a_result_t validate_configuration(k4a_context_t *device, const k4a_devi
 
     if (K4A_SUCCEEDED(result))
     {
-        if (config->color_mode_id < K4A_COLOR_RESOLUTION_OFF ||
-            config->color_mode_id > K4A_COLOR_RESOLUTION_3072P)
+        if (config->color_mode_id < K4A_COLOR_RESOLUTION_OFF || config->color_mode_id > K4A_COLOR_RESOLUTION_3072P)
         {
             result = K4A_RESULT_FAILED;
             LOG_ERROR("The configured color_resolution is not a valid k4a_color_resolution_t value.", 0);
@@ -606,8 +605,7 @@ static k4a_result_t validate_configuration(k4a_context_t *device, const k4a_devi
 
     if (K4A_SUCCEEDED(result))
     {
-        if (config->depth_mode_id < K4A_DEPTH_MODE_OFF ||
-            config->depth_mode_id > K4A_DEPTH_MODE_PASSIVE_IR)
+        if (config->depth_mode_id < K4A_DEPTH_MODE_OFF || config->depth_mode_id > K4A_DEPTH_MODE_PASSIVE_IR)
         {
             result = K4A_RESULT_FAILED;
             LOG_ERROR("The configured depth_mode is not a valid k4a_depth_mode_t value.", 0);
@@ -616,8 +614,7 @@ static k4a_result_t validate_configuration(k4a_context_t *device, const k4a_devi
 
     if (K4A_SUCCEEDED(result))
     {
-        if (config->fps_mode_id != K4A_FRAMES_PER_SECOND_5 &&
-            config->fps_mode_id != K4A_FRAMES_PER_SECOND_15 &&
+        if (config->fps_mode_id != K4A_FRAMES_PER_SECOND_5 && config->fps_mode_id != K4A_FRAMES_PER_SECOND_15 &&
             config->fps_mode_id != K4A_FRAMES_PER_SECOND_30)
         {
             result = K4A_RESULT_FAILED;
@@ -1290,8 +1287,6 @@ k4a_result_t k4a_transformation_depth_image_to_point_cloud(k4a_transformation_t 
                                                                 &xyz_image_descriptor));
 }
 
-
-
 // TODO: comment
 
 struct _device_color_modes
@@ -1336,7 +1331,8 @@ struct _device_fps_modes
     int fps;
 } device_fps_modes[] = { { 5 }, { 15 }, { 30 } };
 
-k4a_result_t k4a_device_get_info(k4a_device_t device_handle, k4a_device_info_t* device_info) {
+k4a_result_t k4a_device_get_info(k4a_device_t device_handle, k4a_device_info_t *device_info)
+{
     if (!device_info)
     {
         return K4A_RESULT_FAILED;
@@ -1349,13 +1345,11 @@ k4a_result_t k4a_device_get_info(k4a_device_t device_handle, k4a_device_info_t* 
     RETURN_VALUE_IF_HANDLE_INVALID(K4A_RESULT_FAILED, k4a_device_t, device_handle);
     k4a_result_t result = K4A_RESULT_SUCCEEDED;
 
-    k4a_device_info_t info = {
-        sizeof(k4a_device_info_t),
-        K4A_ABI_VERSION,
-        K4A_MSFT_VID,
-        K4A_DEPTH_PID,
-        ​​​​​​K4A_CAPABILITY_DEPTH | K4A_CAPABILITY_COLOR | K4A_CAPABILITY_IMU
-    };
+    k4a_device_info_t info = { sizeof(k4a_device_info_t),
+                               K4A_ABI_VERSION,
+                               K4A_MSFT_VID,
+                               K4A_DEPTH_PID,
+                               ​​​​​​K4A_CAPABILITY_DEPTH | K4A_CAPABILITY_COLOR | K4A_CAPABILITY_IMU };
 
     SAFE_COPY_STRUCT(device_info, &info);
 

--- a/src/transformation/transformation.c
+++ b/src/transformation/transformation.c
@@ -118,14 +118,16 @@ static k4a_result_t transformation_create_depth_camera_pinhole(const k4a_calibra
     switch (calibration->depth_mode_id)
     {
     case K4A_DEPTH_MODE_NFOV_2X2BINNED:
-    case K4A_DEPTH_MODE_NFOV_UNBINNED: {
+    case K4A_DEPTH_MODE_NFOV_UNBINNED:
+    {
         fov_degrees[0] = 75;
         fov_degrees[1] = 65;
         break;
     }
     case K4A_DEPTH_MODE_WFOV_2X2BINNED:
     case K4A_DEPTH_MODE_WFOV_UNBINNED:
-    case K4A_DEPTH_MODE_PASSIVE_IR: {
+    case K4A_DEPTH_MODE_PASSIVE_IR:
+    {
         fov_degrees[0] = 120;
         fov_degrees[1] = 120;
         break;
@@ -134,7 +136,6 @@ static k4a_result_t transformation_create_depth_camera_pinhole(const k4a_calibra
         LOG_ERROR("Invalid depth mode.", 0);
         return K4A_RESULT_FAILED;
     }
-
 
     float radian_per_degree = 3.14159265f / 180.f;
     float fx = 0.5f / tanf(0.5f * fov_degrees[0] * radian_per_degree);

--- a/tests/ColorTests/FunctionalTest/color_ft.cpp
+++ b/tests/ColorTests/FunctionalTest/color_ft.cpp
@@ -232,78 +232,90 @@ INSTANTIATE_TEST_CASE_P(color_streaming,
                         color_functional_test,
                         ::testing::Values(
                             // 30 fps tests
-                            color_mode_parameter{ 0, 
-                                                  K4A_IMAGE_FORMAT_COLOR_NV12, 
-                                                  1,  
-                                                  2,  
-                                                  K4A_COLOR_MODE_NV12_720P_EXPECTED_SIZE, 
-                                                  K4A_COLOR_MODE_EXPECTED_FPS_30 }, // 1 = K4A_COLOR_RESOLUTION_720P, 2 = K4A_FRAMES_PER_SECOND_30
+                            color_mode_parameter{ 0,
+                                                  K4A_IMAGE_FORMAT_COLOR_NV12,
+                                                  1,
+                                                  2,
+                                                  K4A_COLOR_MODE_NV12_720P_EXPECTED_SIZE,
+                                                  K4A_COLOR_MODE_EXPECTED_FPS_30 }, // 1 = K4A_COLOR_RESOLUTION_720P, 2
+                                                                                    // = K4A_FRAMES_PER_SECOND_30
                             color_mode_parameter{ 1,
                                                   K4A_IMAGE_FORMAT_COLOR_YUY2,
                                                   1,
                                                   2,
                                                   K4A_COLOR_MODE_YUY2_720P_EXPECTED_SIZE,
-                                                  K4A_COLOR_MODE_EXPECTED_FPS_30 }, // 1 = K4A_COLOR_RESOLUTION_720P, 2 = K4A_FRAMES_PER_SECOND_30
+                                                  K4A_COLOR_MODE_EXPECTED_FPS_30 }, // 1 = K4A_COLOR_RESOLUTION_720P, 2
+                                                                                    // = K4A_FRAMES_PER_SECOND_30
                             color_mode_parameter{ 2,
                                                   K4A_IMAGE_FORMAT_COLOR_MJPG,
                                                   5,
                                                   2,
                                                   K4A_COLOR_MODE_MJPG_EXPECTED_SIZE,
-                                                  K4A_COLOR_MODE_EXPECTED_FPS_30 }, // 5 = K4A_COLOR_RESOLUTION_2160P, 2 = K4A_FRAMES_PER_SECOND_30
+                                                  K4A_COLOR_MODE_EXPECTED_FPS_30 }, // 5 = K4A_COLOR_RESOLUTION_2160P, 2
+                                                                                    // = K4A_FRAMES_PER_SECOND_30
                             color_mode_parameter{ 3,
                                                   K4A_IMAGE_FORMAT_COLOR_MJPG,
                                                   3,
                                                   2,
                                                   K4A_COLOR_MODE_MJPG_EXPECTED_SIZE,
-                                                  K4A_COLOR_MODE_EXPECTED_FPS_30 }, // 3 = K4A_COLOR_RESOLUTION_1440P, 2 = K4A_FRAMES_PER_SECOND_30
+                                                  K4A_COLOR_MODE_EXPECTED_FPS_30 }, // 3 = K4A_COLOR_RESOLUTION_1440P, 2
+                                                                                    // = K4A_FRAMES_PER_SECOND_30
                             color_mode_parameter{ 4,
                                                   K4A_IMAGE_FORMAT_COLOR_MJPG,
                                                   2,
                                                   2,
                                                   K4A_COLOR_MODE_MJPG_EXPECTED_SIZE,
-                                                  K4A_COLOR_MODE_EXPECTED_FPS_30 }, // 2 = K4A_COLOR_RESOLUTION_1080P, 2 = K4A_FRAMES_PER_SECOND_30
+                                                  K4A_COLOR_MODE_EXPECTED_FPS_30 }, // 2 = K4A_COLOR_RESOLUTION_1080P, 2
+                                                                                    // = K4A_FRAMES_PER_SECOND_30
                             color_mode_parameter{ 5,
                                                   K4A_IMAGE_FORMAT_COLOR_MJPG,
                                                   1,
                                                   2,
                                                   K4A_COLOR_MODE_MJPG_EXPECTED_SIZE,
-                                                  K4A_COLOR_MODE_EXPECTED_FPS_30 }, // 1 = K4A_COLOR_RESOLUTION_720P, 2 = K4A_FRAMES_PER_SECOND_30
+                                                  K4A_COLOR_MODE_EXPECTED_FPS_30 }, // 1 = K4A_COLOR_RESOLUTION_720P, 2
+                                                                                    // = K4A_FRAMES_PER_SECOND_30
                             color_mode_parameter{ 6,
                                                   K4A_IMAGE_FORMAT_COLOR_MJPG,
                                                   4,
                                                   2,
                                                   K4A_COLOR_MODE_MJPG_EXPECTED_SIZE,
-                                                  K4A_COLOR_MODE_EXPECTED_FPS_30 }, // 4 = K4A_COLOR_RESOLUTION_1536P, 2 = K4A_FRAMES_PER_SECOND_30
+                                                  K4A_COLOR_MODE_EXPECTED_FPS_30 }, // 4 = K4A_COLOR_RESOLUTION_1536P, 2
+                                                                                    // = K4A_FRAMES_PER_SECOND_30
                             color_mode_parameter{ 7,
                                                   K4A_IMAGE_FORMAT_COLOR_BGRA32,
                                                   5,
                                                   2,
                                                   K4A_COLOR_MODE_RGB_2160P_EXPECTED_SIZE,
-                                                  K4A_COLOR_MODE_EXPECTED_FPS_30 }, // 5 = K4A_COLOR_RESOLUTION_2160P, 2 = K4A_FRAMES_PER_SECOND_30
+                                                  K4A_COLOR_MODE_EXPECTED_FPS_30 }, // 5 = K4A_COLOR_RESOLUTION_2160P, 2
+                                                                                    // = K4A_FRAMES_PER_SECOND_30
                             color_mode_parameter{ 8,
                                                   K4A_IMAGE_FORMAT_COLOR_BGRA32,
                                                   3,
                                                   2,
                                                   K4A_COLOR_MODE_RGB_1440P_EXPECTED_SIZE,
-                                                  K4A_COLOR_MODE_EXPECTED_FPS_30 }, // 3 = K4A_COLOR_RESOLUTION_1440P, 2 = K4A_FRAMES_PER_SECOND_30
+                                                  K4A_COLOR_MODE_EXPECTED_FPS_30 }, // 3 = K4A_COLOR_RESOLUTION_1440P, 2
+                                                                                    // = K4A_FRAMES_PER_SECOND_30
                             color_mode_parameter{ 9,
                                                   K4A_IMAGE_FORMAT_COLOR_BGRA32,
                                                   2,
                                                   2,
                                                   K4A_COLOR_MODE_RGB_1080P_EXPECTED_SIZE,
-                                                  K4A_COLOR_MODE_EXPECTED_FPS_30 }, // 2 = K4A_COLOR_RESOLUTION_1080P, 2 = K4A_FRAMES_PER_SECOND_30
+                                                  K4A_COLOR_MODE_EXPECTED_FPS_30 }, // 2 = K4A_COLOR_RESOLUTION_1080P, 2
+                                                                                    // = K4A_FRAMES_PER_SECOND_30
                             color_mode_parameter{ 10,
                                                   K4A_IMAGE_FORMAT_COLOR_BGRA32,
                                                   1,
                                                   2,
                                                   K4A_COLOR_MODE_RGB_720P_EXPECTED_SIZE,
-                                                  K4A_COLOR_MODE_EXPECTED_FPS_30 }, // 1 = K4A_COLOR_RESOLUTION_720P, 2 = K4A_FRAMES_PER_SECOND_30
+                                                  K4A_COLOR_MODE_EXPECTED_FPS_30 }, // 1 = K4A_COLOR_RESOLUTION_720P, 2
+                                                                                    // = K4A_FRAMES_PER_SECOND_30
                             color_mode_parameter{ 11,
                                                   K4A_IMAGE_FORMAT_COLOR_BGRA32,
                                                   4,
                                                   2,
                                                   K4A_COLOR_MODE_RGB_1536P_EXPECTED_SIZE,
-                                                  K4A_COLOR_MODE_EXPECTED_FPS_30 }, // 4 = K4A_COLOR_RESOLUTION_1536P, 2 = K4A_FRAMES_PER_SECOND_30
+                                                  K4A_COLOR_MODE_EXPECTED_FPS_30 }, // 4 = K4A_COLOR_RESOLUTION_1536P, 2
+                                                                                    // = K4A_FRAMES_PER_SECOND_30
 
                             // 15 fps tests
                             color_mode_parameter{ 12,
@@ -311,171 +323,200 @@ INSTANTIATE_TEST_CASE_P(color_streaming,
                                                   1,
                                                   1,
                                                   K4A_COLOR_MODE_NV12_720P_EXPECTED_SIZE,
-                                                  K4A_COLOR_MODE_EXPECTED_FPS_15 }, // 1 = K4A_COLOR_RESOLUTION_720P, 1 = K4A_FRAMES_PER_SECOND_15
+                                                  K4A_COLOR_MODE_EXPECTED_FPS_15 }, // 1 = K4A_COLOR_RESOLUTION_720P, 1
+                                                                                    // = K4A_FRAMES_PER_SECOND_15
                             color_mode_parameter{ 13,
                                                   K4A_IMAGE_FORMAT_COLOR_YUY2,
                                                   1,
                                                   1,
                                                   K4A_COLOR_MODE_YUY2_720P_EXPECTED_SIZE,
-                                                  K4A_COLOR_MODE_EXPECTED_FPS_15 }, // 1 = K4A_COLOR_RESOLUTION_720P, 1 = K4A_FRAMES_PER_SECOND_15
+                                                  K4A_COLOR_MODE_EXPECTED_FPS_15 }, // 1 = K4A_COLOR_RESOLUTION_720P, 1
+                                                                                    // = K4A_FRAMES_PER_SECOND_15
                             color_mode_parameter{ 14,
                                                   K4A_IMAGE_FORMAT_COLOR_MJPG,
                                                   5,
                                                   1,
                                                   K4A_COLOR_MODE_MJPG_EXPECTED_SIZE,
-                                                  K4A_COLOR_MODE_EXPECTED_FPS_15 }, // 5 = K4A_COLOR_RESOLUTION_2160P, 1 = K4A_FRAMES_PER_SECOND_15
+                                                  K4A_COLOR_MODE_EXPECTED_FPS_15 }, // 5 = K4A_COLOR_RESOLUTION_2160P, 1
+                                                                                    // = K4A_FRAMES_PER_SECOND_15
                             color_mode_parameter{ 15,
                                                   K4A_IMAGE_FORMAT_COLOR_MJPG,
                                                   3,
                                                   1,
                                                   K4A_COLOR_MODE_MJPG_EXPECTED_SIZE,
-                                                  K4A_COLOR_MODE_EXPECTED_FPS_15 }, // 3 = K4A_COLOR_RESOLUTION_1440P, 1 = K4A_FRAMES_PER_SECOND_15
+                                                  K4A_COLOR_MODE_EXPECTED_FPS_15 }, // 3 = K4A_COLOR_RESOLUTION_1440P, 1
+                                                                                    // = K4A_FRAMES_PER_SECOND_15
                             color_mode_parameter{ 16,
                                                   K4A_IMAGE_FORMAT_COLOR_MJPG,
                                                   2,
                                                   1,
                                                   K4A_COLOR_MODE_MJPG_EXPECTED_SIZE,
-                                                  K4A_COLOR_MODE_EXPECTED_FPS_15 }, // 2 = K4A_COLOR_RESOLUTION_1080P, 1 = K4A_FRAMES_PER_SECOND_15
+                                                  K4A_COLOR_MODE_EXPECTED_FPS_15 }, // 2 = K4A_COLOR_RESOLUTION_1080P, 1
+                                                                                    // = K4A_FRAMES_PER_SECOND_15
                             color_mode_parameter{ 17,
                                                   K4A_IMAGE_FORMAT_COLOR_MJPG,
                                                   1,
                                                   1,
                                                   K4A_COLOR_MODE_MJPG_EXPECTED_SIZE,
-                                                  K4A_COLOR_MODE_EXPECTED_FPS_15 }, // 1 = K4A_COLOR_RESOLUTION_720P, 1 = K4A_FRAMES_PER_SECOND_15
+                                                  K4A_COLOR_MODE_EXPECTED_FPS_15 }, // 1 = K4A_COLOR_RESOLUTION_720P, 1
+                                                                                    // = K4A_FRAMES_PER_SECOND_15
                             color_mode_parameter{ 18,
                                                   K4A_IMAGE_FORMAT_COLOR_MJPG,
                                                   6,
                                                   1,
                                                   K4A_COLOR_MODE_MJPG_EXPECTED_SIZE,
-                                                  K4A_COLOR_MODE_EXPECTED_FPS_15 }, // 6 = K4A_COLOR_RESOLUTION_3072P, 1 = K4A_FRAMES_PER_SECOND_15
+                                                  K4A_COLOR_MODE_EXPECTED_FPS_15 }, // 6 = K4A_COLOR_RESOLUTION_3072P, 1
+                                                                                    // = K4A_FRAMES_PER_SECOND_15
                             color_mode_parameter{ 19,
                                                   K4A_IMAGE_FORMAT_COLOR_MJPG,
                                                   4,
                                                   1,
                                                   K4A_COLOR_MODE_MJPG_EXPECTED_SIZE,
-                                                  K4A_COLOR_MODE_EXPECTED_FPS_15 }, // 4 = K4A_COLOR_RESOLUTION_1536P, 1 = K4A_FRAMES_PER_SECOND_15
+                                                  K4A_COLOR_MODE_EXPECTED_FPS_15 }, // 4 = K4A_COLOR_RESOLUTION_1536P, 1
+                                                                                    // = K4A_FRAMES_PER_SECOND_15
                             color_mode_parameter{ 20,
                                                   K4A_IMAGE_FORMAT_COLOR_BGRA32,
                                                   5,
                                                   1,
                                                   K4A_COLOR_MODE_RGB_2160P_EXPECTED_SIZE,
-                                                  K4A_COLOR_MODE_EXPECTED_FPS_15 }, // 5 = K4A_COLOR_RESOLUTION_2160P, 1 = K4A_FRAMES_PER_SECOND_15
+                                                  K4A_COLOR_MODE_EXPECTED_FPS_15 }, // 5 = K4A_COLOR_RESOLUTION_2160P, 1
+                                                                                    // = K4A_FRAMES_PER_SECOND_15
                             color_mode_parameter{ 21,
                                                   K4A_IMAGE_FORMAT_COLOR_BGRA32,
                                                   3,
                                                   1,
                                                   K4A_COLOR_MODE_RGB_1440P_EXPECTED_SIZE,
-                                                  K4A_COLOR_MODE_EXPECTED_FPS_15 }, // 3 = K4A_COLOR_RESOLUTION_1440P, 1 = K4A_FRAMES_PER_SECOND_15
+                                                  K4A_COLOR_MODE_EXPECTED_FPS_15 }, // 3 = K4A_COLOR_RESOLUTION_1440P, 1
+                                                                                    // = K4A_FRAMES_PER_SECOND_15
                             color_mode_parameter{ 22,
                                                   K4A_IMAGE_FORMAT_COLOR_BGRA32,
                                                   2,
                                                   1,
                                                   K4A_COLOR_MODE_RGB_1080P_EXPECTED_SIZE,
-                                                  K4A_COLOR_MODE_EXPECTED_FPS_15 }, // 2 = K4A_COLOR_RESOLUTION_1080P, 1 = K4A_FRAMES_PER_SECOND_15
+                                                  K4A_COLOR_MODE_EXPECTED_FPS_15 }, // 2 = K4A_COLOR_RESOLUTION_1080P, 1
+                                                                                    // = K4A_FRAMES_PER_SECOND_15
                             color_mode_parameter{ 23,
                                                   K4A_IMAGE_FORMAT_COLOR_BGRA32,
                                                   1,
                                                   1,
                                                   K4A_COLOR_MODE_RGB_720P_EXPECTED_SIZE,
-                                                  K4A_COLOR_MODE_EXPECTED_FPS_15 }, // 1 = K4A_COLOR_RESOLUTION_720P, 1 = K4A_FRAMES_PER_SECOND_15
+                                                  K4A_COLOR_MODE_EXPECTED_FPS_15 }, // 1 = K4A_COLOR_RESOLUTION_720P, 1
+                                                                                    // = K4A_FRAMES_PER_SECOND_15
                             color_mode_parameter{ 24,
                                                   K4A_IMAGE_FORMAT_COLOR_BGRA32,
                                                   6,
                                                   1,
                                                   K4A_COLOR_MODE_RGB_3072P_EXPECTED_SIZE,
-                                                  K4A_COLOR_MODE_EXPECTED_FPS_15 }, // 6 = K4A_COLOR_RESOLUTION_3072P, 1 = K4A_FRAMES_PER_SECOND_15
+                                                  K4A_COLOR_MODE_EXPECTED_FPS_15 }, // 6 = K4A_COLOR_RESOLUTION_3072P, 1
+                                                                                    // = K4A_FRAMES_PER_SECOND_15
                             color_mode_parameter{ 25,
                                                   K4A_IMAGE_FORMAT_COLOR_BGRA32,
                                                   4,
                                                   1,
                                                   K4A_COLOR_MODE_RGB_1536P_EXPECTED_SIZE,
-                                                  K4A_COLOR_MODE_EXPECTED_FPS_15 }, // 4 = K4A_COLOR_RESOLUTION_1536P, 1 = K4A_FRAMES_PER_SECOND_15
+                                                  K4A_COLOR_MODE_EXPECTED_FPS_15 }, // 4 = K4A_COLOR_RESOLUTION_1536P, 1
+                                                                                    // = K4A_FRAMES_PER_SECOND_15
 
                             // 5 fps tests
                             color_mode_parameter{ 26,
                                                   K4A_IMAGE_FORMAT_COLOR_NV12,
                                                   1,
                                                   0,
-                                                  K4A_COLOR_MODE_NV12_720P_EXPECTED_SIZE, // 1 = K4A_COLOR_RESOLUTION_720P, 0 = K4A_FRAMES_PER_SECOND_5
+                                                  K4A_COLOR_MODE_NV12_720P_EXPECTED_SIZE, // 1 =
+                                                                                          // K4A_COLOR_RESOLUTION_720P,
+                                                                                          // 0 = K4A_FRAMES_PER_SECOND_5
                                                   K4A_COLOR_MODE_EXPECTED_FPS_5 },
                             color_mode_parameter{ 27,
                                                   K4A_IMAGE_FORMAT_COLOR_YUY2,
                                                   1,
                                                   0,
                                                   K4A_COLOR_MODE_YUY2_720P_EXPECTED_SIZE,
-                                                  K4A_COLOR_MODE_EXPECTED_FPS_5 }, // 1 = K4A_COLOR_RESOLUTION_720P, 0 = K4A_FRAMES_PER_SECOND_5
+                                                  K4A_COLOR_MODE_EXPECTED_FPS_5 }, // 1 = K4A_COLOR_RESOLUTION_720P, 0 =
+                                                                                   // K4A_FRAMES_PER_SECOND_5
                             color_mode_parameter{ 28,
                                                   K4A_IMAGE_FORMAT_COLOR_MJPG,
                                                   5,
                                                   0,
                                                   K4A_COLOR_MODE_MJPG_EXPECTED_SIZE,
-                                                  K4A_COLOR_MODE_EXPECTED_FPS_5 }, // 5 = K4A_COLOR_RESOLUTION_2160P, 0 = K4A_FRAMES_PER_SECOND_5
+                                                  K4A_COLOR_MODE_EXPECTED_FPS_5 }, // 5 = K4A_COLOR_RESOLUTION_2160P, 0
+                                                                                   // = K4A_FRAMES_PER_SECOND_5
                             color_mode_parameter{ 29,
                                                   K4A_IMAGE_FORMAT_COLOR_MJPG,
                                                   3,
                                                   0,
                                                   K4A_COLOR_MODE_MJPG_EXPECTED_SIZE,
-                                                  K4A_COLOR_MODE_EXPECTED_FPS_5 }, // 3 = K4A_COLOR_RESOLUTION_1440P, 0 = K4A_FRAMES_PER_SECOND_5
+                                                  K4A_COLOR_MODE_EXPECTED_FPS_5 }, // 3 = K4A_COLOR_RESOLUTION_1440P, 0
+                                                                                   // = K4A_FRAMES_PER_SECOND_5
                             color_mode_parameter{ 30,
                                                   K4A_IMAGE_FORMAT_COLOR_MJPG,
                                                   2,
                                                   0,
                                                   K4A_COLOR_MODE_MJPG_EXPECTED_SIZE,
-                                                  K4A_COLOR_MODE_EXPECTED_FPS_5 }, // 2 = K4A_COLOR_RESOLUTION_1080P, 0 = K4A_FRAMES_PER_SECOND_5
+                                                  K4A_COLOR_MODE_EXPECTED_FPS_5 }, // 2 = K4A_COLOR_RESOLUTION_1080P, 0
+                                                                                   // = K4A_FRAMES_PER_SECOND_5
                             color_mode_parameter{ 31,
                                                   K4A_IMAGE_FORMAT_COLOR_MJPG,
                                                   1,
                                                   0,
                                                   K4A_COLOR_MODE_MJPG_EXPECTED_SIZE,
-                                                  K4A_COLOR_MODE_EXPECTED_FPS_5 }, // 1 = K4A_COLOR_RESOLUTION_720P, 0 = K4A_FRAMES_PER_SECOND_5
+                                                  K4A_COLOR_MODE_EXPECTED_FPS_5 }, // 1 = K4A_COLOR_RESOLUTION_720P, 0 =
+                                                                                   // K4A_FRAMES_PER_SECOND_5
                             color_mode_parameter{ 32,
                                                   K4A_IMAGE_FORMAT_COLOR_MJPG,
                                                   6,
                                                   0,
                                                   K4A_COLOR_MODE_MJPG_EXPECTED_SIZE,
-                                                  K4A_COLOR_MODE_EXPECTED_FPS_5 }, // 6 = K4A_COLOR_RESOLUTION_3072P, 0 = K4A_FRAMES_PER_SECOND_5
+                                                  K4A_COLOR_MODE_EXPECTED_FPS_5 }, // 6 = K4A_COLOR_RESOLUTION_3072P, 0
+                                                                                   // = K4A_FRAMES_PER_SECOND_5
                             color_mode_parameter{ 33,
                                                   K4A_IMAGE_FORMAT_COLOR_MJPG,
                                                   4,
                                                   0,
                                                   K4A_COLOR_MODE_MJPG_EXPECTED_SIZE,
-                                                  K4A_COLOR_MODE_EXPECTED_FPS_5 }, // 4 = K4A_COLOR_RESOLUTION_1536P, 0 = K4A_FRAMES_PER_SECOND_5
+                                                  K4A_COLOR_MODE_EXPECTED_FPS_5 }, // 4 = K4A_COLOR_RESOLUTION_1536P, 0
+                                                                                   // = K4A_FRAMES_PER_SECOND_5
                             color_mode_parameter{ 34,
                                                   K4A_IMAGE_FORMAT_COLOR_BGRA32,
                                                   5,
                                                   0,
                                                   K4A_COLOR_MODE_RGB_2160P_EXPECTED_SIZE,
-                                                  K4A_COLOR_MODE_EXPECTED_FPS_5 }, // 5 = K4A_COLOR_RESOLUTION_2160P, 0 = K4A_FRAMES_PER_SECOND_5
+                                                  K4A_COLOR_MODE_EXPECTED_FPS_5 }, // 5 = K4A_COLOR_RESOLUTION_2160P, 0
+                                                                                   // = K4A_FRAMES_PER_SECOND_5
                             color_mode_parameter{ 35,
                                                   K4A_IMAGE_FORMAT_COLOR_BGRA32,
                                                   3,
                                                   0,
                                                   K4A_COLOR_MODE_RGB_1440P_EXPECTED_SIZE,
-                                                  K4A_COLOR_MODE_EXPECTED_FPS_5 }, // 3 = K4A_COLOR_RESOLUTION_1440P, 0 = K4A_FRAMES_PER_SECOND_5
+                                                  K4A_COLOR_MODE_EXPECTED_FPS_5 }, // 3 = K4A_COLOR_RESOLUTION_1440P, 0
+                                                                                   // = K4A_FRAMES_PER_SECOND_5
                             color_mode_parameter{ 36,
                                                   K4A_IMAGE_FORMAT_COLOR_BGRA32,
                                                   2,
                                                   0,
                                                   K4A_COLOR_MODE_RGB_1080P_EXPECTED_SIZE,
-                                                  K4A_COLOR_MODE_EXPECTED_FPS_5 }, // 2 = K4A_COLOR_RESOLUTION_1080P, 0 = K4A_FRAMES_PER_SECOND_5
+                                                  K4A_COLOR_MODE_EXPECTED_FPS_5 }, // 2 = K4A_COLOR_RESOLUTION_1080P, 0
+                                                                                   // = K4A_FRAMES_PER_SECOND_5
                             color_mode_parameter{ 37,
                                                   K4A_IMAGE_FORMAT_COLOR_BGRA32,
                                                   1,
                                                   0,
                                                   K4A_COLOR_MODE_RGB_720P_EXPECTED_SIZE,
-                                                  K4A_COLOR_MODE_EXPECTED_FPS_5 }, // 1 = K4A_COLOR_RESOLUTION_720P, 0 = K4A_FRAMES_PER_SECOND_5
+                                                  K4A_COLOR_MODE_EXPECTED_FPS_5 }, // 1 = K4A_COLOR_RESOLUTION_720P, 0 =
+                                                                                   // K4A_FRAMES_PER_SECOND_5
                             color_mode_parameter{ 38,
                                                   K4A_IMAGE_FORMAT_COLOR_BGRA32,
                                                   6,
                                                   0,
                                                   K4A_COLOR_MODE_RGB_3072P_EXPECTED_SIZE,
-                                                  K4A_COLOR_MODE_EXPECTED_FPS_5 }, // 6 = K4A_COLOR_RESOLUTION_3072P, 0 = K4A_FRAMES_PER_SECOND_5
+                                                  K4A_COLOR_MODE_EXPECTED_FPS_5 }, // 6 = K4A_COLOR_RESOLUTION_3072P, 0
+                                                                                   // = K4A_FRAMES_PER_SECOND_5
                             color_mode_parameter{ 39,
                                                   K4A_IMAGE_FORMAT_COLOR_BGRA32,
                                                   4,
                                                   0,
                                                   K4A_COLOR_MODE_RGB_1536P_EXPECTED_SIZE,
-                                                  K4A_COLOR_MODE_EXPECTED_FPS_5 })); // 4 = K4A_COLOR_RESOLUTION_1536P, 0 = K4A_FRAMES_PER_SECOND_5
+                                                  K4A_COLOR_MODE_EXPECTED_FPS_5 })); // 4 = K4A_COLOR_RESOLUTION_1536P,
+                                                                                     // 0 = K4A_FRAMES_PER_SECOND_5
 
 /**
  *  Functional test for verifying that changing modes actually causes data to be returned in the right mode
@@ -826,7 +867,8 @@ void color_control_test::control_test_worker(const k4a_color_control_command_t c
 
     if (supports_auto)
     {
-        ASSERT_EQ(K4A_RESULT_SUCCEEDED, k4a_device_set_color_control(m_device, command, K4A_COLOR_CONTROL_MODE_AUTO, 0));
+        ASSERT_EQ(K4A_RESULT_SUCCEEDED,
+                  k4a_device_set_color_control(m_device, command, K4A_COLOR_CONTROL_MODE_AUTO, 0));
     }
     else
     {
@@ -854,7 +896,8 @@ void color_control_test::control_test_worker(const k4a_color_control_command_t c
             ASSERT_EQ(value, map_manual_exposure(testValue, b_sixty_hertz)) << testValue << " was the value tested\n";
             if (cameras_running)
             {
-                ASSERT_TRUE(validate_image_exposure_setting(value, b_sixty_hertz, (k4a_fps_t)config.fps_mode_id)) << "1";
+                ASSERT_TRUE(validate_image_exposure_setting(value, b_sixty_hertz, (k4a_fps_t)config.fps_mode_id))
+                    << "1";
             }
 
             testValue = threshold;
@@ -903,7 +946,8 @@ void color_control_test::control_test_worker(const k4a_color_control_command_t c
         for (int32_t testValue = min_value; testValue <= max_value; testValue += step_value)
         {
             // Set test value
-            ASSERT_EQ(K4A_RESULT_SUCCEEDED, k4a_device_set_color_control(m_device, command, K4A_COLOR_CONTROL_MODE_MANUAL, testValue));
+            ASSERT_EQ(K4A_RESULT_SUCCEEDED,
+                      k4a_device_set_color_control(m_device, command, K4A_COLOR_CONTROL_MODE_MANUAL, testValue));
             ASSERT_EQ(K4A_RESULT_SUCCEEDED, k4a_device_get_color_control(m_device, command, &current_mode, &value));
             ASSERT_EQ(current_mode, K4A_COLOR_CONTROL_MODE_MANUAL);
             ASSERT_EQ(value, testValue);

--- a/tests/RecordTests/FunctionalTest/k4a_cpp_ft.cpp
+++ b/tests/RecordTests/FunctionalTest/k4a_cpp_ft.cpp
@@ -109,7 +109,10 @@ TEST_F(k4a_cpp_ft, k4a)
         k4a_color_mode_info_t color_mode_info2 = { sizeof(k4a_color_mode_info_t), K4A_ABI_VERSION, { 0 } };
         k4a_device_get_color_mode(kinect.handle(), 2, &color_mode_info2); // K4A_COLOR_RESOLUTION_1080P
 
-        cal = calibration::get_from_raw(raw_cal.data(), raw_cal.size(), depth_mode_info.mode_id, color_mode_info2.mode_id);
+        cal = calibration::get_from_raw(raw_cal.data(),
+                                        raw_cal.size(),
+                                        depth_mode_info.mode_id,
+                                        color_mode_info2.mode_id);
         ASSERT_EQ(cal.color_mode_id, (uint32_t)2);
     }
 

--- a/tests/RecordTests/UnitTest/playback_ut.cpp
+++ b/tests/RecordTests/UnitTest/playback_ut.cpp
@@ -300,8 +300,11 @@ TEST_F(playback_ut, playback_seek_test)
 
     stream_result = k4a_playback_get_next_capture(handle, &capture);
     ASSERT_EQ(stream_result, K4A_STREAM_RESULT_SUCCEEDED);
-    ASSERT_TRUE(
-        validate_test_capture(capture, timestamps, config.color_format, config.color_mode_info.mode_id, config.depth_mode_info.mode_id));
+    ASSERT_TRUE(validate_test_capture(capture,
+                                      timestamps,
+                                      config.color_format,
+                                      config.color_mode_info.mode_id,
+                                      config.depth_mode_info.mode_id));
     k4a_capture_release(capture);
 
     stream_result = k4a_playback_get_next_imu_sample(handle, &imu_sample);
@@ -357,7 +360,8 @@ TEST_F(playback_ut, playback_seek_test)
         ASSERT_EQ(stream_result, K4A_STREAM_RESULT_SUCCEEDED);
         ASSERT_TRUE(validate_test_capture(capture,
                                           timestamps,
-                                          config.color_format, config.color_mode_info.mode_id,
+                                          config.color_format,
+                                          config.color_mode_info.mode_id,
                                           config.depth_mode_info.mode_id));
         k4a_capture_release(capture);
 
@@ -377,7 +381,8 @@ TEST_F(playback_ut, playback_seek_test)
         ASSERT_EQ(stream_result, K4A_STREAM_RESULT_SUCCEEDED);
         ASSERT_TRUE(validate_test_capture(capture,
                                           timestamps,
-                                          config.color_format, config.color_mode_info.mode_id,
+                                          config.color_format,
+                                          config.color_mode_info.mode_id,
                                           config.depth_mode_info.mode_id));
         k4a_capture_release(capture);
 
@@ -409,7 +414,8 @@ TEST_F(playback_ut, playback_seek_test)
         ASSERT_EQ(stream_result, K4A_STREAM_RESULT_SUCCEEDED);
         ASSERT_TRUE(validate_test_capture(capture,
                                           timestamps,
-                                          config.color_format, config.color_mode_info.mode_id,
+                                          config.color_format,
+                                          config.color_mode_info.mode_id,
                                           config.depth_mode_info.mode_id));
         k4a_capture_release(capture);
 
@@ -429,7 +435,8 @@ TEST_F(playback_ut, playback_seek_test)
         ASSERT_EQ(stream_result, K4A_STREAM_RESULT_SUCCEEDED);
         ASSERT_TRUE(validate_test_capture(capture,
                                           timestamps,
-                                          config.color_format, config.color_mode_info.mode_id,
+                                          config.color_format,
+                                          config.color_mode_info.mode_id,
                                           config.depth_mode_info.mode_id));
         k4a_capture_release(capture);
 
@@ -457,7 +464,8 @@ TEST_F(playback_ut, playback_seek_test)
         ASSERT_EQ(stream_result, K4A_STREAM_RESULT_SUCCEEDED);
         ASSERT_TRUE(validate_test_capture(capture,
                                           timestamps,
-                                          config.color_format, config.color_mode_info.mode_id,
+                                          config.color_format,
+                                          config.color_mode_info.mode_id,
                                           config.depth_mode_info.mode_id));
         k4a_capture_release(capture);
 
@@ -474,7 +482,8 @@ TEST_F(playback_ut, playback_seek_test)
         ASSERT_EQ(stream_result, K4A_STREAM_RESULT_SUCCEEDED);
         ASSERT_TRUE(validate_test_capture(capture,
                                           timestamps,
-                                          config.color_format, config.color_mode_info.mode_id,
+                                          config.color_format,
+                                          config.color_mode_info.mode_id,
                                           config.depth_mode_info.mode_id));
         k4a_capture_release(capture);
 
@@ -490,7 +499,8 @@ TEST_F(playback_ut, playback_seek_test)
         ASSERT_EQ(stream_result, K4A_STREAM_RESULT_SUCCEEDED);
         ASSERT_TRUE(validate_test_capture(capture,
                                           timestamps,
-                                          config.color_format, config.color_mode_info.mode_id,
+                                          config.color_format,
+                                          config.color_mode_info.mode_id,
                                           config.depth_mode_info.mode_id));
         k4a_capture_release(capture);
 
@@ -507,7 +517,8 @@ TEST_F(playback_ut, playback_seek_test)
         ASSERT_EQ(stream_result, K4A_STREAM_RESULT_SUCCEEDED);
         ASSERT_TRUE(validate_test_capture(capture,
                                           timestamps,
-                                          config.color_format, config.color_mode_info.mode_id,
+                                          config.color_format,
+                                          config.color_mode_info.mode_id,
                                           config.depth_mode_info.mode_id));
         k4a_capture_release(capture);
 
@@ -552,8 +563,11 @@ TEST_F(playback_ut, open_skipped_frames_file)
     ASSERT_EQ(stream_result, K4A_STREAM_RESULT_SUCCEEDED);
     // According to the generated sample sequence, the first capture is missing a Color image
     // i == 0 in generation loop (see sample_recordings.cpp)
-    ASSERT_TRUE(
-        validate_test_capture(capture, timestamps, config.color_format, K4A_COLOR_RESOLUTION_OFF, config.depth_mode_info.mode_id));
+    ASSERT_TRUE(validate_test_capture(capture,
+                                      timestamps,
+                                      config.color_format,
+                                      K4A_COLOR_RESOLUTION_OFF,
+                                      config.depth_mode_info.mode_id));
     k4a_capture_release(capture);
 
     // Test seek to beginning
@@ -567,8 +581,11 @@ TEST_F(playback_ut, open_skipped_frames_file)
     stream_result = k4a_playback_get_next_capture(handle, &capture);
     ASSERT_EQ(stream_result, K4A_STREAM_RESULT_SUCCEEDED);
     // i == 0, Color image is dropped
-    ASSERT_TRUE(
-        validate_test_capture(capture, timestamps, config.color_format, K4A_COLOR_RESOLUTION_OFF, config.depth_mode_info.mode_id));
+    ASSERT_TRUE(validate_test_capture(capture,
+                                      timestamps,
+                                      config.color_format,
+                                      K4A_COLOR_RESOLUTION_OFF,
+                                      config.depth_mode_info.mode_id));
     k4a_capture_release(capture);
 
     // Test seek past beginning
@@ -580,8 +597,11 @@ TEST_F(playback_ut, open_skipped_frames_file)
     stream_result = k4a_playback_get_next_capture(handle, &capture);
     ASSERT_EQ(stream_result, K4A_STREAM_RESULT_SUCCEEDED);
     // i == 0, Color image is dropped
-    ASSERT_TRUE(
-        validate_test_capture(capture, timestamps, config.color_format, K4A_COLOR_RESOLUTION_OFF, config.depth_mode_info.mode_id));
+    ASSERT_TRUE(validate_test_capture(capture,
+                                      timestamps,
+                                      config.color_format,
+                                      K4A_COLOR_RESOLUTION_OFF,
+                                      config.depth_mode_info.mode_id));
     k4a_capture_release(capture);
 
     // Test seek to end
@@ -598,8 +618,11 @@ TEST_F(playback_ut, open_skipped_frames_file)
     stream_result = k4a_playback_get_previous_capture(handle, &capture);
     ASSERT_EQ(stream_result, K4A_STREAM_RESULT_SUCCEEDED);
     // i == 99, No images are dropped
-    ASSERT_TRUE(
-        validate_test_capture(capture, timestamps, config.color_format, config.color_mode_info.mode_id, config.depth_mode_info.mode_id));
+    ASSERT_TRUE(validate_test_capture(capture,
+                                      timestamps,
+                                      config.color_format,
+                                      config.color_mode_info.mode_id,
+                                      config.depth_mode_info.mode_id));
     k4a_capture_release(capture);
 
     // Test seek to end, relative to start
@@ -615,8 +638,11 @@ TEST_F(playback_ut, open_skipped_frames_file)
     stream_result = k4a_playback_get_previous_capture(handle, &capture);
     ASSERT_EQ(stream_result, K4A_STREAM_RESULT_SUCCEEDED);
     // i == 99, No images are dropped
-    ASSERT_TRUE(
-        validate_test_capture(capture, timestamps, config.color_format, config.color_mode_info.mode_id, config.depth_mode_info.mode_id));
+    ASSERT_TRUE(validate_test_capture(capture,
+                                      timestamps,
+                                      config.color_format,
+                                      config.color_mode_info.mode_id,
+                                      config.depth_mode_info.mode_id));
     k4a_capture_release(capture);
 
     // Test seek to middle of the recording, then read forward
@@ -629,8 +655,11 @@ TEST_F(playback_ut, open_skipped_frames_file)
     stream_result = k4a_playback_get_next_capture(handle, &capture);
     ASSERT_EQ(stream_result, K4A_STREAM_RESULT_SUCCEEDED);
     // i == 49, Depth image is dropped
-    ASSERT_TRUE(
-        validate_test_capture(capture, timestamps, config.color_format, config.color_mode_info.mode_id, K4A_DEPTH_MODE_OFF));
+    ASSERT_TRUE(validate_test_capture(capture,
+                                      timestamps,
+                                      config.color_format,
+                                      config.color_mode_info.mode_id,
+                                      K4A_DEPTH_MODE_OFF));
     k4a_capture_release(capture);
 
     // Test seek to middle of the recording, then read backward
@@ -644,8 +673,11 @@ TEST_F(playback_ut, open_skipped_frames_file)
     stream_result = k4a_playback_get_previous_capture(handle, &capture);
     ASSERT_EQ(stream_result, K4A_STREAM_RESULT_SUCCEEDED);
     // i == 48, Color image is dropped
-    ASSERT_TRUE(
-        validate_test_capture(capture, timestamps, config.color_format, K4A_COLOR_RESOLUTION_OFF, config.depth_mode_info.mode_id));
+    ASSERT_TRUE(validate_test_capture(capture,
+                                      timestamps,
+                                      config.color_format,
+                                      K4A_COLOR_RESOLUTION_OFF,
+                                      config.depth_mode_info.mode_id));
     k4a_capture_release(capture);
 
     // Read the rest of the file
@@ -824,7 +856,8 @@ TEST_F(playback_ut, open_start_offset_file)
         ASSERT_EQ(stream_result, K4A_STREAM_RESULT_SUCCEEDED);
         ASSERT_TRUE(validate_test_capture(capture,
                                           timestamps,
-                                          config.color_format, config.color_mode_info.mode_id,
+                                          config.color_format,
+                                          config.color_mode_info.mode_id,
                                           config.depth_mode_info.mode_id));
         k4a_capture_release(capture);
         timestamps[0] += timestamp_delta;
@@ -845,7 +878,8 @@ TEST_F(playback_ut, open_start_offset_file)
         ASSERT_EQ(stream_result, K4A_STREAM_RESULT_SUCCEEDED);
         ASSERT_TRUE(validate_test_capture(capture,
                                           timestamps,
-                                          config.color_format, config.color_mode_info.mode_id,
+                                          config.color_format,
+                                          config.color_mode_info.mode_id,
                                           config.depth_mode_info.mode_id));
         k4a_capture_release(capture);
     }
@@ -938,8 +972,11 @@ TEST_F(playback_ut, open_color_only_file)
     k4a_capture_t capture = NULL;
     k4a_stream_result_t stream_result = k4a_playback_get_next_capture(handle, &capture);
     ASSERT_EQ(stream_result, K4A_STREAM_RESULT_SUCCEEDED);
-    ASSERT_TRUE(
-        validate_test_capture(capture, timestamps, config.color_format, config.color_mode_info.mode_id, config.depth_mode_info.mode_id));
+    ASSERT_TRUE(validate_test_capture(capture,
+                                      timestamps,
+                                      config.color_format,
+                                      config.color_mode_info.mode_id,
+                                      config.depth_mode_info.mode_id));
     k4a_capture_release(capture);
 
     k4a_playback_close(handle);
@@ -973,8 +1010,11 @@ TEST_F(playback_ut, open_depth_only_file)
     k4a_capture_t capture = NULL;
     k4a_stream_result_t stream_result = k4a_playback_get_next_capture(handle, &capture);
     ASSERT_EQ(stream_result, K4A_STREAM_RESULT_SUCCEEDED);
-    ASSERT_TRUE(
-        validate_test_capture(capture, timestamps, config.color_format, config.color_mode_info.mode_id, config.depth_mode_info.mode_id));
+    ASSERT_TRUE(validate_test_capture(capture,
+                                      timestamps,
+                                      config.color_format,
+                                      config.color_mode_info.mode_id,
+                                      config.depth_mode_info.mode_id));
     k4a_capture_release(capture);
 
     k4a_playback_close(handle);
@@ -1008,8 +1048,11 @@ TEST_F(playback_ut, open_bgra_color_file)
     k4a_capture_t capture = NULL;
     k4a_stream_result_t stream_result = k4a_playback_get_next_capture(handle, &capture);
     ASSERT_EQ(stream_result, K4A_STREAM_RESULT_SUCCEEDED);
-    ASSERT_TRUE(
-        validate_test_capture(capture, timestamps, config.color_format, config.color_mode_info.mode_id, config.depth_mode_info.mode_id));
+    ASSERT_TRUE(validate_test_capture(capture,
+                                      timestamps,
+                                      config.color_format,
+                                      config.color_mode_info.mode_id,
+                                      config.depth_mode_info.mode_id));
     k4a_capture_release(capture);
 
     k4a_playback_close(handle);

--- a/tests/RecordTests/UnitTest/test_helpers.cpp
+++ b/tests/RecordTests/UnitTest/test_helpers.cpp
@@ -28,7 +28,8 @@
 
 k4a_capture_t create_test_capture(uint64_t timestamp_us[3],
                                   k4a_image_format_t color_format,
-                                  uint32_t color_mode_id, uint32_t depth_mode_id)
+                                  uint32_t color_mode_id,
+                                  uint32_t depth_mode_id)
 {
     k4a_capture_t capture = NULL;
     k4a_result_t result = k4a_capture_create(&capture);
@@ -84,7 +85,8 @@ bool validate_test_capture(k4a_capture_t capture,
         {
             uint32_t width = 0;
             uint32_t height = 0;
-            EXIT_IF_FALSE(k4a_convert_resolution_to_width_height((k4a_color_resolution_t)color_mode_id, &width, &height));
+            EXIT_IF_FALSE(
+                k4a_convert_resolution_to_width_height((k4a_color_resolution_t)color_mode_id, &width, &height));
 
             uint32_t color_stride = 0;
             if (color_format == K4A_IMAGE_FORMAT_COLOR_NV12)

--- a/tests/RecordTests/UnitTest/test_helpers.h
+++ b/tests/RecordTests/UnitTest/test_helpers.h
@@ -33,7 +33,8 @@ static const size_t test_frame_count = 100;
 
 k4a_capture_t create_test_capture(uint64_t timestamp_us[3],
                                   k4a_image_format_t color_format,
-                                  uint32_t color_mode_id, uint32_t depth_mode_id);
+                                  uint32_t color_mode_id,
+                                  uint32_t depth_mode_id);
 bool validate_test_capture(k4a_capture_t capture,
                            uint64_t timestamp_us[3],
                            k4a_image_format_t color_format,

--- a/tests/Transformation/transformation.cpp
+++ b/tests/Transformation/transformation.cpp
@@ -52,16 +52,9 @@ protected:
                                                   30,
                                                   250,
                                                   3000 }; // K4A_DEPTH_MODE_WFOV_2X2BINNED
-        k4a_color_mode_info_t color_mode_info = { sizeof(k4a_color_mode_info_t), 
-                                                  K4A_ABI_VERSION, 
-                                                  5,     
-                                                  3840, 
-                                                  2160,
-                                                  K4A_IMAGE_FORMAT_COLOR_MJPG,   
-                                                  90.0f,           
-                                                  59.0f, 
-                                                  5,    
-                                                  30 }; // K4A_COLOR_RESOLUTION_2160P
+        k4a_color_mode_info_t color_mode_info =
+            { sizeof(k4a_color_mode_info_t), K4A_ABI_VERSION, 5,     3840, 2160,
+              K4A_IMAGE_FORMAT_COLOR_MJPG,   90.0f,           59.0f, 5,    30 }; // K4A_COLOR_RESOLUTION_2160P
 
         k4a_result_t result = k4a_calibration_get_from_raw(g_test_json,
                                                            sizeof(g_test_json),
@@ -581,30 +574,113 @@ TEST_F(transformation_ut, transformation_all_image_functions_with_failure_cases)
 
     for (int i = 0; i < 5; i++)
     {
-        k4a_depth_mode_info_t depth_mode_info = { sizeof(k4a_depth_mode_info_t), K4A_ABI_VERSION, 0, false, 0, 0, K4A_IMAGE_FORMAT_DEPTH16, 0.0f, 0.0f, 0, 0, 0, 0 };
-        k4a_color_mode_info_t color_mode_info = { sizeof(k4a_color_mode_info_t), K4A_ABI_VERSION, 0, 0, 0, K4A_IMAGE_FORMAT_COLOR_MJPG, 0, 0, 0, 0 };
+        k4a_depth_mode_info_t depth_mode_info = { sizeof(k4a_depth_mode_info_t),
+                                                  K4A_ABI_VERSION,
+                                                  0,
+                                                  false,
+                                                  0,
+                                                  0,
+                                                  K4A_IMAGE_FORMAT_DEPTH16,
+                                                  0.0f,
+                                                  0.0f,
+                                                  0,
+                                                  0,
+                                                  0,
+                                                  0 };
+        k4a_color_mode_info_t color_mode_info =
+            { sizeof(k4a_color_mode_info_t), K4A_ABI_VERSION, 0, 0, 0, K4A_IMAGE_FORMAT_COLOR_MJPG, 0, 0, 0, 0 };
 
         switch (i)
         {
         case 0:
-            depth_mode_info = { sizeof(k4a_depth_mode_info_t), K4A_ABI_VERSION, 2, false, 640, 576, K4A_IMAGE_FORMAT_DEPTH16, 75.0f, 65.0f, 5, 30, 500, 4000 }; // K4A_DEPTH_MODE_NFOV_UNBINNED
-            color_mode_info = { sizeof(k4a_color_mode_info_t), K4A_ABI_VERSION, 0, 0, 0, K4A_IMAGE_FORMAT_COLOR_MJPG, 0, 0, 0, 0 }; // K4A_COLOR_RESOLUTION_OFF
+            depth_mode_info = { sizeof(k4a_depth_mode_info_t),
+                                K4A_ABI_VERSION,
+                                2,
+                                false,
+                                640,
+                                576,
+                                K4A_IMAGE_FORMAT_DEPTH16,
+                                75.0f,
+                                65.0f,
+                                5,
+                                30,
+                                500,
+                                4000 }; // K4A_DEPTH_MODE_NFOV_UNBINNED
+            color_mode_info = {
+                sizeof(k4a_color_mode_info_t), K4A_ABI_VERSION, 0, 0, 0, K4A_IMAGE_FORMAT_COLOR_MJPG, 0, 0, 0, 0
+            }; // K4A_COLOR_RESOLUTION_OFF
             break;
         case 1:
-            depth_mode_info = { sizeof(k4a_depth_mode_info_t), K4A_ABI_VERSION, 0, false, 0, 0, K4A_IMAGE_FORMAT_DEPTH16, 0.0f, 0.0f, 0, 0, 0, 0 }; // K4A_DEPTH_MODE_OFF
-            color_mode_info = { sizeof(k4a_color_mode_info_t), K4A_ABI_VERSION, 1, 1280, 720, K4A_IMAGE_FORMAT_COLOR_MJPG, 90.0f, 59.0f, 5, 30  }; // K4A_COLOR_RESOLUTION_720P
+            depth_mode_info = { sizeof(k4a_depth_mode_info_t),
+                                K4A_ABI_VERSION,
+                                0,
+                                false,
+                                0,
+                                0,
+                                K4A_IMAGE_FORMAT_DEPTH16,
+                                0.0f,
+                                0.0f,
+                                0,
+                                0,
+                                0,
+                                0 }; // K4A_DEPTH_MODE_OFF
+            color_mode_info =
+                { sizeof(k4a_color_mode_info_t), K4A_ABI_VERSION, 1,     1280, 720,
+                  K4A_IMAGE_FORMAT_COLOR_MJPG,   90.0f,           59.0f, 5,    30 }; // K4A_COLOR_RESOLUTION_720P
             break;
         case 2:
-            depth_mode_info = { sizeof(k4a_depth_mode_info_t), K4A_ABI_VERSION, 1, false, 320, 288, K4A_IMAGE_FORMAT_DEPTH16, 75.0f, 65.0f, 5, 30, 500, 5800 }; // K4A_DEPTH_MODE_NFOV_2X2BINNED
-            color_mode_info = { sizeof(k4a_color_mode_info_t), K4A_ABI_VERSION, 1, 1280, 720, K4A_IMAGE_FORMAT_COLOR_MJPG, 90.0f, 59.0f, 5, 30  }; // K4A_COLOR_RESOLUTION_720P
+            depth_mode_info = { sizeof(k4a_depth_mode_info_t),
+                                K4A_ABI_VERSION,
+                                1,
+                                false,
+                                320,
+                                288,
+                                K4A_IMAGE_FORMAT_DEPTH16,
+                                75.0f,
+                                65.0f,
+                                5,
+                                30,
+                                500,
+                                5800 }; // K4A_DEPTH_MODE_NFOV_2X2BINNED
+            color_mode_info =
+                { sizeof(k4a_color_mode_info_t), K4A_ABI_VERSION, 1,     1280, 720,
+                  K4A_IMAGE_FORMAT_COLOR_MJPG,   90.0f,           59.0f, 5,    30 }; // K4A_COLOR_RESOLUTION_720P
             break;
         case 3:
-            depth_mode_info = { sizeof(k4a_depth_mode_info_t), K4A_ABI_VERSION, 2, false, 640, 576, K4A_IMAGE_FORMAT_DEPTH16, 75.0f, 65.0f, 5, 30, 500, 4000 }; // K4A_DEPTH_MODE_NFOV_UNBINNED
-            color_mode_info = { sizeof(k4a_color_mode_info_t), K4A_ABI_VERSION, 5, 3840, 2160, K4A_IMAGE_FORMAT_COLOR_MJPG, 90.0f, 59.0f, 5, 30 }; // K4A_COLOR_RESOLUTION_2160P
+            depth_mode_info = { sizeof(k4a_depth_mode_info_t),
+                                K4A_ABI_VERSION,
+                                2,
+                                false,
+                                640,
+                                576,
+                                K4A_IMAGE_FORMAT_DEPTH16,
+                                75.0f,
+                                65.0f,
+                                5,
+                                30,
+                                500,
+                                4000 }; // K4A_DEPTH_MODE_NFOV_UNBINNED
+            color_mode_info =
+                { sizeof(k4a_color_mode_info_t), K4A_ABI_VERSION, 5,     3840, 2160,
+                  K4A_IMAGE_FORMAT_COLOR_MJPG,   90.0f,           59.0f, 5,    30 }; // K4A_COLOR_RESOLUTION_2160P
             break;
         default:
-            depth_mode_info = { sizeof(k4a_depth_mode_info_t), K4A_ABI_VERSION, 2, false, 640, 576, K4A_IMAGE_FORMAT_DEPTH16, 75.0f, 65.0f, 5, 30, 500, 4000 }; // K4A_DEPTH_MODE_NFOV_UNBINNED
-            color_mode_info = { sizeof(k4a_color_mode_info_t), K4A_ABI_VERSION, 1, 1280, 720, K4A_IMAGE_FORMAT_COLOR_MJPG, 90.0f, 59.0f, 5, 30  }; // K4A_COLOR_RESOLUTION_720P
+            depth_mode_info = { sizeof(k4a_depth_mode_info_t),
+                                K4A_ABI_VERSION,
+                                2,
+                                false,
+                                640,
+                                576,
+                                K4A_IMAGE_FORMAT_DEPTH16,
+                                75.0f,
+                                65.0f,
+                                5,
+                                30,
+                                500,
+                                4000 }; // K4A_DEPTH_MODE_NFOV_UNBINNED
+            color_mode_info =
+                { sizeof(k4a_color_mode_info_t), K4A_ABI_VERSION, 1,     1280, 720,
+                  K4A_IMAGE_FORMAT_COLOR_MJPG,   90.0f,           59.0f, 5,    30 }; // K4A_COLOR_RESOLUTION_720P
         }
 
         k4a_calibration_t calibration;

--- a/tools/k4arecorder/main.cpp
+++ b/tools/k4arecorder/main.cpp
@@ -377,8 +377,11 @@ int main(int argc, char **argv)
         cmd_parser.PrintOptions();
         return 0;
     }
-   
-    if (recording_rate == 2 && (recording_depth_mode == 4 || recording_color_resolution == 6)) // 2 = K4A_FRAMES_PER_SECOND_30, 4 = K4A_DEPTH_MODE_WFOV_UNBINNED, 6 = K4A_COLOR_RESOLUTION_3072P
+
+    if (recording_rate == 2 &&
+        (recording_depth_mode == 4 || recording_color_resolution == 6)) // 2 = K4A_FRAMES_PER_SECOND_30, 4 =
+                                                                        // K4A_DEPTH_MODE_WFOV_UNBINNED, 6 =
+                                                                        // K4A_COLOR_RESOLUTION_3072P
     {
         if (!recording_rate_set)
         {

--- a/tools/k4arecorder/recorder.cpp
+++ b/tools/k4arecorder/recorder.cpp
@@ -85,7 +85,9 @@ int do_recording(uint8_t device_index,
 
     uint32_t camera_fps = k4a_convert_fps_mode_id_to_uint(device_config->fps_mode_id);
 
-    if (camera_fps <= 0 || (device_config->color_mode_id == 0 && device_config->depth_mode_id == 0)) // 0 = K4A_COLOR_RESOLUTION_OFF, 0 = K4A_DEPTH_MODE_OFF
+    if (camera_fps <= 0 ||
+        (device_config->color_mode_id == 0 && device_config->depth_mode_id == 0)) // 0 = K4A_COLOR_RESOLUTION_OFF, 0 =
+                                                                                  // K4A_DEPTH_MODE_OFF
     {
         std::cerr << "Either the color or depth modes must be enabled to record." << std::endl;
         return 1;

--- a/tools/k4aviewer/k4acolorimageconverter.cpp
+++ b/tools/k4aviewer/k4acolorimageconverter.cpp
@@ -49,7 +49,8 @@ public:
     }
 
 protected:
-    explicit K4AColorImageConverterBase(k4a_color_mode_info_t color_mode_info) : m_dimensions(GetColorDimensions(color_mode_info))
+    explicit K4AColorImageConverterBase(k4a_color_mode_info_t color_mode_info) :
+        m_dimensions(GetColorDimensions(color_mode_info))
     {
         m_expectedBufferSize = sizeof(BgraPixel) * static_cast<size_t>(m_dimensions.Width * m_dimensions.Height);
     }
@@ -219,7 +220,11 @@ public:
         return ImageConversionResult::Success;
     }
 
-    K4AMJPGImageConverter(k4a_color_mode_info_t color_mode_info) :  K4AColorImageConverterBase(color_mode_info),  m_decompressor(tjInitDecompress()) {}
+    K4AMJPGImageConverter(k4a_color_mode_info_t color_mode_info) :
+        K4AColorImageConverterBase(color_mode_info),
+        m_decompressor(tjInitDecompress())
+    {
+    }
 
     ~K4AMJPGImageConverter() override
     {

--- a/tools/k4aviewer/k4adepthimageconverter.h
+++ b/tools/k4aviewer/k4adepthimageconverter.h
@@ -23,7 +23,10 @@ class K4ADepthImageConverter
     : public K4ADepthImageConverterBase<K4A_IMAGE_FORMAT_DEPTH16, K4ADepthPixelColorizer::ColorizeBlueToRed>
 {
 public:
-    explicit K4ADepthImageConverter(k4a_depth_mode_info_t depth_mode_info) : K4ADepthImageConverterBase(depth_mode_info, GetDepthModeRange(depth_mode_info)) {}
+    explicit K4ADepthImageConverter(k4a_depth_mode_info_t depth_mode_info) :
+        K4ADepthImageConverterBase(depth_mode_info, GetDepthModeRange(depth_mode_info))
+    {
+    }
 
     ~K4ADepthImageConverter() override = default;
 

--- a/tools/k4aviewer/k4adevicedockcontrol.cpp
+++ b/tools/k4aviewer/k4adevicedockcontrol.cpp
@@ -347,11 +347,11 @@ K4ADockControlStatus K4ADeviceDockControl::Show()
         std::vector<std::pair<int, std::string>> depth_mode_items;
         std::vector<k4a_depth_mode_info_t> depth_modes = m_device.get_depth_modes();
         size_t depth_modes_size = depth_modes.size();
-        for (int d = 1; d < depth_modes_size; d++)
+        for (size_t d = 1; d < depth_modes_size; d++) // Start at index = 1 (0 is off).
         {
             k4a_depth_mode_info_t depth_mode = depth_modes[d];
-            int width = (int)depth_mode.width;
-            int height = (int)depth_mode.height;
+            int width = static_cast<int>(depth_mode.width);
+            int height = static_cast<int>(depth_mode.height);
             float fov = depth_mode.horizontal_fov;
 
             std::string description = "";
@@ -378,7 +378,12 @@ K4ADockControlStatus K4ADeviceDockControl::Show()
             depth_mode_items.push_back({ depth_mode.mode_id, (const std::string)description });
         }
 
-        depthModeUpdated |= ImGuiExtensions::K4AComboBox("##Depth", "", ImGuiComboFlags_None, depth_mode_items, pDepthModeInfo, depthSettingsEditable);
+        depthModeUpdated |= ImGuiExtensions::K4AComboBox("##Depth",
+                                                         "",
+                                                         ImGuiComboFlags_None,
+                                                         depth_mode_items,
+                                                         pDepthModeInfo,
+                                                         depthSettingsEditable);
 
         ImGui::TreePop();
     }
@@ -403,18 +408,22 @@ K4ADockControlStatus K4ADeviceDockControl::Show()
         auto *pColorFormat = reinterpret_cast<int *>(&m_config.ColorFormat);
 
         ImGui::Text("Format");
-        colorFormatUpdated |= ImGuiExtensions::K4ARadioButton("BGRA", pColorFormat, K4A_IMAGE_FORMAT_COLOR_BGRA32, colorSettingsEditable);
+        colorFormatUpdated |=
+            ImGuiExtensions::K4ARadioButton("BGRA", pColorFormat, K4A_IMAGE_FORMAT_COLOR_BGRA32, colorSettingsEditable);
         ImGui::SameLine();
-        colorFormatUpdated |= ImGuiExtensions::K4ARadioButton("MJPG", pColorFormat, K4A_IMAGE_FORMAT_COLOR_MJPG, colorSettingsEditable);
+        colorFormatUpdated |=
+            ImGuiExtensions::K4ARadioButton("MJPG", pColorFormat, K4A_IMAGE_FORMAT_COLOR_MJPG, colorSettingsEditable);
         ImGui::SameLine();
-        colorFormatUpdated |= ImGuiExtensions::K4ARadioButton("NV12", pColorFormat, K4A_IMAGE_FORMAT_COLOR_NV12, colorSettingsEditable);
+        colorFormatUpdated |=
+            ImGuiExtensions::K4ARadioButton("NV12", pColorFormat, K4A_IMAGE_FORMAT_COLOR_NV12, colorSettingsEditable);
         ImGui::SameLine();
-        colorFormatUpdated |= ImGuiExtensions::K4ARadioButton("YUY2", pColorFormat, K4A_IMAGE_FORMAT_COLOR_YUY2, colorSettingsEditable);
+        colorFormatUpdated |=
+            ImGuiExtensions::K4ARadioButton("YUY2", pColorFormat, K4A_IMAGE_FORMAT_COLOR_YUY2, colorSettingsEditable);
 
         // Uncompressed formats are only supported at 720p.
 
         // TODO: tooltip if not supported in NV12 or YUY2 mode
-        //const char *imageFormatHelpMessage = "Not supported in NV12 or YUY2 mode!";
+        // const char *imageFormatHelpMessage = "Not supported in NV12 or YUY2 mode!";
 
         const bool imageFormatSupportsHighResolution = m_config.ColorFormat != K4A_IMAGE_FORMAT_COLOR_NV12 &&
                                                        m_config.ColorFormat != K4A_IMAGE_FORMAT_COLOR_YUY2;
@@ -433,11 +442,11 @@ K4ADockControlStatus K4ADeviceDockControl::Show()
         std::vector<std::pair<int, std::string>> color_mode_items;
         std::vector<k4a_color_mode_info_t> color_modes = m_device.get_color_modes();
         size_t color_modes_size = color_modes.size();
-        for (int c = 1; c < color_modes_size; c++)
+        for (size_t c = 1; c < color_modes_size; c++) // Start at index = 1 (0 is off).
         {
             k4a_color_mode_info_t color_mode = color_modes[c];
-            int width = (int)color_mode.width;
-            int height = (int)color_mode.height;
+            int width = static_cast<int>(color_mode.width);
+            int height = static_cast<int>(color_mode.height);
             int common_factor = m_device.get_common_factor(width, height);
 
             std::string description = "";
@@ -448,11 +457,16 @@ K4ADockControlStatus K4ADeviceDockControl::Show()
             description += std::to_string(height) + "p ";
             description += std::to_string(width / common_factor) + ":" + std::to_string(height / common_factor);
 
-            color_mode_items.push_back({ color_mode.mode_id, (const std::string) description });
+            color_mode_items.push_back({ color_mode.mode_id, (const std::string)description });
         }
 
-        colorResolutionUpdated |= ImGuiExtensions::K4AComboBox("##Resolution", "", ImGuiComboFlags_None, color_mode_items, pColorModeInfo, colorSettingsEditable);
-        
+        colorResolutionUpdated |= ImGuiExtensions::K4AComboBox("##Resolution",
+                                                               "",
+                                                               ImGuiComboFlags_None,
+                                                               color_mode_items,
+                                                               pColorModeInfo,
+                                                               colorSettingsEditable);
+
         ImGui::TreePop();
     }
     if (ImGui::TreeNode("Color Controls"))
@@ -608,7 +622,10 @@ K4ADockControlStatus K4ADeviceDockControl::Show()
         }
     }
 
-    const bool supports30fps = !(m_config.EnableColorCamera && m_config.color_mode_id == 6) && !(m_config.EnableDepthCamera && m_config.depth_mode_id == 4); // 6 = K4A_COLOR_RESOLUTION_3072P, 4 = K4A_DEPTH_MODE_WFOV_UNBINNED
+    const bool supports30fps = !(m_config.EnableColorCamera && m_config.color_mode_id == 6) &&
+                               !(m_config.EnableDepthCamera &&
+                                 m_config.depth_mode_id == 4); // 6 = K4A_COLOR_RESOLUTION_3072P, 4 =
+                                                               // K4A_DEPTH_MODE_WFOV_UNBINNED
 
     const bool enableFramerate = !deviceIsStarted && (m_config.EnableColorCamera || m_config.EnableDepthCamera);
 
@@ -625,7 +642,7 @@ K4ADockControlStatus K4ADeviceDockControl::Show()
     std::vector<std::pair<int, std::string>> fps_mode_items;
     std::vector<k4a_fps_mode_info_t> fps_modes = m_device.get_fps_modes();
     size_t fps_modes_size = fps_modes.size();
-    for (int f = 0; f < fps_modes_size; f++)
+    for (size_t f = 0; f < fps_modes_size; f++)
     {
         k4a_fps_mode_info_t fps_mode = fps_modes[f];
         int fps = (int)fps_mode.fps;
@@ -634,7 +651,8 @@ K4ADockControlStatus K4ADeviceDockControl::Show()
         fps_mode_items.push_back({ fps_mode.mode_id, (const std::string)description });
     }
 
-    framerateUpdated |= ImGuiExtensions::K4AComboBox("##Framerate", "", ImGuiComboFlags_None, fps_mode_items, pFPSModeInfo);
+    framerateUpdated |=
+        ImGuiExtensions::K4AComboBox("##Framerate", "", ImGuiComboFlags_None, fps_mode_items, pFPSModeInfo);
 
     ImGui::Unindent();
 
@@ -687,10 +705,10 @@ K4ADockControlStatus K4ADeviceDockControl::Show()
             int maxDepthDelay = 0;
             switch (m_config.fps_mode_id)
             {
-            case 2:  // 2 = K4A_FRAMES_PER_SECOND_30
+            case 2: // 2 = K4A_FRAMES_PER_SECOND_30
                 maxDepthDelay = std::micro::den / 30;
                 break;
-            case 1:  // 1 = K4A_FRAMES_PER_SECOND_15
+            case 1: // 1 = K4A_FRAMES_PER_SECOND_15
                 maxDepthDelay = std::micro::den / 15;
                 break;
             case 0: // 0 = K4A_FRAMES_PER_SECOND_5
@@ -824,7 +842,8 @@ K4ADockControlStatus K4ADeviceDockControl::Show()
 
         ImGui::Separator();
 
-        const bool pointCloudViewerAvailable = m_config.EnableDepthCamera && m_config.depth_mode_id != 5 && m_camerasStarted; // 5 = K4A_DEPTH_MODE_PASSIVE_IR
+        const bool pointCloudViewerAvailable = m_config.EnableDepthCamera && m_config.depth_mode_id != 5 &&
+                                               m_camerasStarted; // 5 = K4A_DEPTH_MODE_PASSIVE_IR
 
         K4AWindowSet::ShowModeSelector(&m_currentViewType,
                                        true,
@@ -1064,7 +1083,6 @@ void K4ADeviceDockControl::SetViewType(K4AWindowSet::ViewType viewType)
         }
     }
 
-    
     k4a_depth_mode_info_t depth_mode_info = m_device.get_depth_mode(m_config.depth_mode_id);
     k4a_color_mode_info_t color_mode_info = m_device.get_color_mode(m_config.color_mode_id);
 
@@ -1086,7 +1104,8 @@ void K4ADeviceDockControl::SetViewType(K4AWindowSet::ViewType viewType)
         try
         {
             k4a::calibration calib = m_device.get_calibration(depth_mode_info.mode_id, color_mode_info.mode_id);
-            bool rgbPointCloudAvailable = m_config.EnableColorCamera && m_config.ColorFormat == K4A_IMAGE_FORMAT_COLOR_BGRA32;
+            bool rgbPointCloudAvailable = m_config.EnableColorCamera &&
+                                          m_config.ColorFormat == K4A_IMAGE_FORMAT_COLOR_BGRA32;
             K4AWindowSet::StartPointCloudWindow(m_deviceSerialNumber.c_str(),
                                                 calib,
                                                 depth_mode_info,

--- a/tools/k4aviewer/k4ainfraredimageconverter.h
+++ b/tools/k4aviewer/k4ainfraredimageconverter.h
@@ -21,7 +21,10 @@ class K4AInfraredImageConverter
     : public K4ADepthImageConverterBase<K4A_IMAGE_FORMAT_IR16, K4ADepthPixelColorizer::ColorizeGreyscale>
 {
 public:
-    explicit K4AInfraredImageConverter(k4a_depth_mode_info_t depth_mode_info) : K4ADepthImageConverterBase<K4A_IMAGE_FORMAT_IR16, K4ADepthPixelColorizer::ColorizeGreyscale>(depth_mode_info, GetIrLevels(depth_mode_info)){};
+    explicit K4AInfraredImageConverter(k4a_depth_mode_info_t depth_mode_info) :
+        K4ADepthImageConverterBase<K4A_IMAGE_FORMAT_IR16, K4ADepthPixelColorizer::ColorizeGreyscale>(
+            depth_mode_info,
+            GetIrLevels(depth_mode_info)){};
 
     ~K4AInfraredImageConverter() override = default;
 

--- a/tools/k4aviewer/k4apointcloudvisualizer.h
+++ b/tools/k4aviewer/k4apointcloudvisualizer.h
@@ -57,7 +57,9 @@ public:
     PointCloudVisualizationResult SetColorizationStrategy(ColorizationStrategy strategy);
     void SetPointSize(int size);
 
-    K4APointCloudVisualizer(bool enableColorPointCloud, const k4a::calibration &calibrationData, k4a_depth_mode_info_t depth_mode_info);
+    K4APointCloudVisualizer(bool enableColorPointCloud,
+                            const k4a::calibration &calibrationData,
+                            k4a_depth_mode_info_t depth_mode_info);
     ~K4APointCloudVisualizer() = default;
 
     K4APointCloudVisualizer(const K4APointCloudVisualizer &) = delete;

--- a/tools/k4aviewer/k4apointcloudwindow.h
+++ b/tools/k4aviewer/k4apointcloudwindow.h
@@ -48,7 +48,8 @@ private:
     std::shared_ptr<K4AViewerImage> m_texture;
     std::shared_ptr<K4ANonBufferingCaptureSource> m_captureSource;
 
-    K4APointCloudVisualizer::ColorizationStrategy m_colorizationStrategy = K4APointCloudVisualizer::ColorizationStrategy::Shaded;
+    K4APointCloudVisualizer::ColorizationStrategy m_colorizationStrategy =
+        K4APointCloudVisualizer::ColorizationStrategy::Shaded;
     int m_pointSize;
 
     bool m_enableColorPointCloud = false;

--- a/tools/k4aviewer/k4arecordingdockcontrol.cpp
+++ b/tools/k4aviewer/k4arecordingdockcontrol.cpp
@@ -54,7 +54,7 @@ K4ARecordingDockControl::K4ARecordingDockControl(std::string &&path, k4a::playba
 
     switch (m_recordConfiguration.fps_mode_info.mode_id)
     {
-    case 0:  // 0 = K4A_FRAMES_PER_SECOND_5
+    case 0: // 0 = K4A_FRAMES_PER_SECOND_5
         m_playbackThreadState.TimePerFrame = std::chrono::microseconds(std::micro::den / (std::micro::num * 5));
         break;
 
@@ -62,7 +62,7 @@ K4ARecordingDockControl::K4ARecordingDockControl(std::string &&path, k4a::playba
         m_playbackThreadState.TimePerFrame = std::chrono::microseconds(std::micro::den / (std::micro::num * 15));
         break;
 
-    case 2:  // 2 = K4A_FRAMES_PER_SECOND_30
+    case 2: // 2 = K4A_FRAMES_PER_SECOND_30
     default:
         m_playbackThreadState.TimePerFrame = std::chrono::microseconds(std::micro::den / (std::micro::num * 30));
         break;
@@ -477,7 +477,8 @@ void K4ARecordingDockControl::SetViewType(K4AWindowSet::ViewType viewType)
         try
         {
             k4a::calibration calibration = m_playbackThreadState.Recording.get_calibration();
-            k4a_record_configuration_t record_configuration = m_playbackThreadState.Recording.get_record_configuration();
+            k4a_record_configuration_t record_configuration =
+                m_playbackThreadState.Recording.get_record_configuration();
             k4a_depth_mode_info_t depth_mode_info = record_configuration.depth_mode_info;
             K4AWindowSet::StartPointCloudWindow(m_filenameLabel.c_str(),
                                                 std::move(calibration),

--- a/tools/k4aviewer/k4astaticimageproperties.h
+++ b/tools/k4aviewer/k4astaticimageproperties.h
@@ -51,7 +51,7 @@ inline std::pair<uint16_t, uint16_t> GetDepthModeRange(k4a_depth_mode_info_t dep
     if (K4ASourceSelectionDockControl::SelectedDevice != -1)
     {
         // TODO: not sure if we need this check for passive
-        if (!depth_mode_info.passive_ir_only) 
+        if (!depth_mode_info.passive_ir_only)
         {
             return { (uint16_t)depth_mode_info.min_range, (uint16_t)depth_mode_info.max_range };
         }

--- a/tools/k4aviewer/k4atypeoperators.cpp
+++ b/tools/k4aviewer/k4atypeoperators.cpp
@@ -145,14 +145,14 @@ std::istream &operator>>(std::istream &s, k4a_wired_sync_mode_t &val)
 
 // TODO: remove?
 
-//namespace
+// namespace
 //{
-//constexpr char FramesPerSecond5[] = "K4A_FRAMES_PER_SECOND_5";
-//constexpr char FramesPerSecond15[] = "K4A_FRAMES_PER_SECOND_15";
-//constexpr char FramesPerSecond30[] = "K4A_FRAMES_PER_SECOND_30";
+// constexpr char FramesPerSecond5[] = "K4A_FRAMES_PER_SECOND_5";
+// constexpr char FramesPerSecond15[] = "K4A_FRAMES_PER_SECOND_15";
+// constexpr char FramesPerSecond30[] = "K4A_FRAMES_PER_SECOND_30";
 //} // namespace
 //
-//std::ostream &operator<<(std::ostream &s, const k4a_fps_t &val)
+// std::ostream &operator<<(std::ostream &s, const k4a_fps_t &val)
 //{
 //    switch (val)
 //    {
@@ -171,7 +171,7 @@ std::istream &operator>>(std::istream &s, k4a_wired_sync_mode_t &val)
 //    return s;
 //}
 //
-//std::istream &operator>>(std::istream &s, k4a_fps_t &val)
+// std::istream &operator>>(std::istream &s, k4a_fps_t &val)
 //{
 //    std::string str;
 //    s >> str;
@@ -194,17 +194,17 @@ std::istream &operator>>(std::istream &s, k4a_wired_sync_mode_t &val)
 //    return s;
 //}
 //
-//namespace
+// namespace
 //{
-//constexpr char DepthModeOff[] = "K4A_DEPTH_MODE_OFF";
-//constexpr char DepthModeNfov2x2Binned[] = "K4A_DEPTH_MODE_NFOV_2X2BINNED";
-//constexpr char DepthModeNfovUnbinned[] = "K4A_DEPTH_MODE_NFOV_UNBINNED";
-//constexpr char DepthModeWfov2x2Binned[] = "K4A_DEPTH_MODE_WFOV_2X2BINNED";
-//constexpr char DepthModeWfovUnbinned[] = "K4A_DEPTH_MODE_WFOV_UNBINNED";
-//constexpr char DepthModePassiveIr[] = "K4A_DEPTH_MODE_PASSIVE_IR";
+// constexpr char DepthModeOff[] = "K4A_DEPTH_MODE_OFF";
+// constexpr char DepthModeNfov2x2Binned[] = "K4A_DEPTH_MODE_NFOV_2X2BINNED";
+// constexpr char DepthModeNfovUnbinned[] = "K4A_DEPTH_MODE_NFOV_UNBINNED";
+// constexpr char DepthModeWfov2x2Binned[] = "K4A_DEPTH_MODE_WFOV_2X2BINNED";
+// constexpr char DepthModeWfovUnbinned[] = "K4A_DEPTH_MODE_WFOV_UNBINNED";
+// constexpr char DepthModePassiveIr[] = "K4A_DEPTH_MODE_PASSIVE_IR";
 //} // namespace
 //
-//std::ostream &operator<<(std::ostream &s, const k4a_depth_mode_t &val)
+// std::ostream &operator<<(std::ostream &s, const k4a_depth_mode_t &val)
 //{
 //    switch (val)
 //    {
@@ -232,7 +232,7 @@ std::istream &operator>>(std::istream &s, k4a_wired_sync_mode_t &val)
 //    return s;
 //}
 //
-//std::istream &operator>>(std::istream &s, k4a_depth_mode_t &val)
+// std::istream &operator>>(std::istream &s, k4a_depth_mode_t &val)
 //{
 //    std::string str;
 //    s >> str;
@@ -267,18 +267,18 @@ std::istream &operator>>(std::istream &s, k4a_wired_sync_mode_t &val)
 //    return s;
 //}
 //
-//namespace
+// namespace
 //{
-//constexpr char ColorResolutionOff[] = "K4A_COLOR_RESOLUTION_OFF";
-//constexpr char ColorResolution720p[] = "K4A_COLOR_RESOLUTION_720P";
-//constexpr char ColorResolution1080p[] = "K4A_COLOR_RESOLUTION_1080P";
-//constexpr char ColorResolution1440p[] = "K4A_COLOR_RESOLUTION_1440P";
-//constexpr char ColorResolution1536p[] = "K4A_COLOR_RESOLUTION_1536P";
-//constexpr char ColorResolution2160p[] = "K4A_COLOR_RESOLUTION_2160P";
-//constexpr char ColorResolution3072p[] = "K4A_COLOR_RESOLUTION_3072P";
+// constexpr char ColorResolutionOff[] = "K4A_COLOR_RESOLUTION_OFF";
+// constexpr char ColorResolution720p[] = "K4A_COLOR_RESOLUTION_720P";
+// constexpr char ColorResolution1080p[] = "K4A_COLOR_RESOLUTION_1080P";
+// constexpr char ColorResolution1440p[] = "K4A_COLOR_RESOLUTION_1440P";
+// constexpr char ColorResolution1536p[] = "K4A_COLOR_RESOLUTION_1536P";
+// constexpr char ColorResolution2160p[] = "K4A_COLOR_RESOLUTION_2160P";
+// constexpr char ColorResolution3072p[] = "K4A_COLOR_RESOLUTION_3072P";
 //} // namespace
 //
-//std::ostream &operator<<(std::ostream &s, const k4a_color_resolution_t &val)
+// std::ostream &operator<<(std::ostream &s, const k4a_color_resolution_t &val)
 //{
 //    switch (val)
 //    {
@@ -309,7 +309,7 @@ std::istream &operator>>(std::istream &s, k4a_wired_sync_mode_t &val)
 //    return s;
 //}
 //
-//std::istream &operator>>(std::istream &s, k4a_color_resolution_t &val)
+// std::istream &operator>>(std::istream &s, k4a_color_resolution_t &val)
 //{
 //    std::string str;
 //    s >> str;

--- a/tools/k4aviewer/k4atypeoperators.h
+++ b/tools/k4aviewer/k4atypeoperators.h
@@ -32,14 +32,14 @@ std::ostream &operator<<(std::ostream &s, const k4a_wired_sync_mode_t &val);
 std::istream &operator>>(std::istream &s, k4a_wired_sync_mode_t &val);
 
 // TODO: remove?
-//std::ostream &operator<<(std::ostream &s, const k4a_fps_t &val);
-//std::istream &operator>>(std::istream &s, k4a_fps_t &val);
+// std::ostream &operator<<(std::ostream &s, const k4a_fps_t &val);
+// std::istream &operator>>(std::istream &s, k4a_fps_t &val);
 //
-//std::ostream &operator<<(std::ostream &s, const k4a_depth_mode_t &val);
-//std::istream &operator>>(std::istream &s, k4a_depth_mode_t &val);
+// std::ostream &operator<<(std::ostream &s, const k4a_depth_mode_t &val);
+// std::istream &operator>>(std::istream &s, k4a_depth_mode_t &val);
 //
-//std::ostream &operator<<(std::ostream &s, const k4a_color_resolution_t &val);
-//std::istream &operator>>(std::istream &s, k4a_color_resolution_t &val);
+// std::ostream &operator<<(std::ostream &s, const k4a_color_resolution_t &val);
+// std::istream &operator>>(std::istream &s, k4a_color_resolution_t &val);
 
 std::ostream &operator<<(std::ostream &s, const k4a_image_format_t &val);
 std::istream &operator>>(std::istream &s, k4a_image_format_t &val);

--- a/tools/k4aviewer/k4aviewersettingsmanager.cpp
+++ b/tools/k4aviewer/k4aviewersettingsmanager.cpp
@@ -282,18 +282,21 @@ std::ostream &operator<<(std::ostream &s, const ViewerOption &val)
 // The UI doesn't quite line up with the struct we actually need to give to the K4A API, so
 // we have to do a bit of conversion.
 //
-k4a_device_configuration_t K4ADeviceConfiguration::ToK4ADeviceConfiguration(k4a::device * device) const
+k4a_device_configuration_t K4ADeviceConfiguration::ToK4ADeviceConfiguration(k4a::device *device) const
 {
     k4a_device_configuration_t deviceConfig;
 
     deviceConfig.color_format = ColorFormat;
 
-    k4a_depth_mode_info_t depth_mode_info = device->get_depth_mode(EnableDepthCamera ? depth_mode_id : 0); // 0 = K4A_DEPTH_MODE_OFF
-    k4a_color_mode_info_t color_mode_info = device->get_color_mode(EnableColorCamera ? color_mode_id : 0); // 0 = K4A_COLOR_RESOLUTION_OFF
+    k4a_depth_mode_info_t depth_mode_info = device->get_depth_mode(EnableDepthCamera ? depth_mode_id :
+                                                                                       0); // 0 = K4A_DEPTH_MODE_OFF
+    k4a_color_mode_info_t color_mode_info = device->get_color_mode(EnableColorCamera ? color_mode_id :
+                                                                                       0); // 0 =
+                                                                                           // K4A_COLOR_RESOLUTION_OFF
     k4a_fps_mode_info_t fps_mode_info = device->get_fps_mode(fps_mode_id);
 
     deviceConfig.color_mode_id = color_mode_info.mode_id;
-    deviceConfig.depth_mode_id = depth_mode_info.mode_id;      
+    deviceConfig.depth_mode_id = depth_mode_info.mode_id;
     deviceConfig.fps_mode_id = fps_mode_info.mode_id;
 
     deviceConfig.depth_delay_off_color_usec = DepthDelayOffColorUsec;

--- a/tools/k4aviewer/k4aviewersettingsmanager.h
+++ b/tools/k4aviewer/k4aviewersettingsmanager.h
@@ -28,9 +28,11 @@ struct K4ADeviceConfiguration
     bool EnableDepthCamera = true;
     k4a_image_format_t ColorFormat = K4A_IMAGE_FORMAT_COLOR_BGRA32;
 
-    //k4a_color_mode_info_t color_mode_info = { sizeof(k4a_color_mode_info_t), K4A_ABI_VERSION, 1, 1280, 720, K4A_IMAGE_FORMAT_COLOR_MJPG, 90.0f, 59.0f, 5, 30  }; // K4A_COLOR_RESOLUTION_720P
-    //k4a_depth_mode_info_t depth_mode_info = { sizeof(k4a_depth_mode_info_t), K4A_ABI_VERSION, 2, false, 640, 576, K4A_IMAGE_FORMAT_DEPTH16, 75.0f, 65.0f, 5, 30, 500, 4000 }; // K4A_DEPTH_MODE_NFOV_UNBINNED
-    //k4a_fps_mode_info_t fps_mode_info = { sizeof(k4a_fps_mode_info_t), K4A_ABI_VERSION, 2, 30 }; // K4A_FRAMES_PER_SECOND_30
+    // k4a_color_mode_info_t color_mode_info = { sizeof(k4a_color_mode_info_t), K4A_ABI_VERSION, 1, 1280, 720,
+    // K4A_IMAGE_FORMAT_COLOR_MJPG, 90.0f, 59.0f, 5, 30  }; // K4A_COLOR_RESOLUTION_720P k4a_depth_mode_info_t
+    // depth_mode_info = { sizeof(k4a_depth_mode_info_t), K4A_ABI_VERSION, 2, false, 640, 576,
+    // K4A_IMAGE_FORMAT_DEPTH16, 75.0f, 65.0f, 5, 30, 500, 4000 }; // K4A_DEPTH_MODE_NFOV_UNBINNED k4a_fps_mode_info_t
+    // fps_mode_info = { sizeof(k4a_fps_mode_info_t), K4A_ABI_VERSION, 2, 30 }; // K4A_FRAMES_PER_SECOND_30
 
     uint32_t color_mode_id = 1;
     uint32_t depth_mode_id = 2;
@@ -49,7 +51,7 @@ struct K4ADeviceConfiguration
 
     // Convert to a k4a_device_configuration_t suitable for passing to the K4A API
     //
-    k4a_device_configuration_t ToK4ADeviceConfiguration(k4a::device * device) const;
+    k4a_device_configuration_t ToK4ADeviceConfiguration(k4a::device *device) const;
 };
 
 std::istream &operator>>(std::istream &s, K4ADeviceConfiguration &val);


### PR DESCRIPTION
…t not being able to convert from float to enum, and in tools/k4aviewer/k4arecordingdockcontrol.cpp about mismatched signed/unsigned comparison.

The rest of the changes are formatting enforced by clang with the command line command "ninja clangformat". The command line build enforces this step before building.

Fixed Bug 5456.

<!-- 
     All pull requests should fix a Triage Approved issue. Put that issue # here:
     e.g. ## Fixes #300. 
-->
## Fixes #

### Description of the changes:
-
-
-

<!-- Please check off the appropriate boxes with [x] before submitting your pull request -->
### Before submitting a Pull Request:
- [ ] I reviewed [CONTRIBUTING.md](https://github.com/Microsoft/Azure-Kinect-Sensor-SDK/blob/develop/CONTRIBUTING.md)
- [ ] I [built my changes](https://github.com/Microsoft/Azure-Kinect-Sensor-SDK/blob/develop/docs/building.md) locally
- [ ] I ran the [unit tests](https://github.com/Microsoft/Azure-Kinect-Sensor-SDK/blob/develop/docs/testing.md)
- [ ] I ran the [functional tests](https://github.com/Microsoft/Azure-Kinect-Sensor-SDK/blob/develop/docs/testing.md) with a device
- [ ] I ran the [performance tests](https://github.com/Microsoft/Azure-Kinect-Sensor-SDK/blob/develop/docs/testing.md) with a device

### I tested changes on: <!-- it's not required to have tested both, just indicate which one you tried -->
- [ ] Windows
- [ ] Linux


<!-- Specify how you tested your changes (i.e. manual/ad-hoc testing, automated testing, new automated tests added)-->

