### PR TITLE
K4A API: Adding to docstrings that functions may return status of UNS…

### DIFF
--- a/include/k4a/k4a.h
+++ b/include/k4a/k4a.h
@@ -60,7 +60,8 @@ K4A_EXPORT uint32_t k4a_device_get_installed_count(void);
  * The least critical error the user wants to be notified about.
  *
  * \return ::K4A_RESULT_SUCCEEDED if the callback function was set or cleared successfully. ::K4A_RESULT_FAILED if an
- * error is encountered or the callback function has already been set.
+ * error is encountered or the callback function has already been set. ::K4A_RESULT_UNSUPPORTED if the operation is
+ * not supported.
  *
  * \remarks
  * Call this function to set or clear the callback function that is used to deliver debug messages to the caller. This
@@ -107,7 +108,8 @@ K4A_EXPORT k4a_result_t k4a_set_debug_message_handler(k4a_logging_message_cb_t *
  * is no longer needed.
  *
  * \return ::K4A_RESULT_SUCCEEDED if the callback function was set or cleared successfully. ::K4A_RESULT_FAILED if an
- * error is encountered or the callback function has already been set.
+ * error is encountered or the callback function has already been set. ::K4A_RESULT_UNSUPPORTED if the operation is
+ * not supported.
  *
  * \remarks
  * Call this function to hook memory allocation by the SDK. Calling with both \p allocate and \p free as NULL will
@@ -142,7 +144,8 @@ K4A_EXPORT k4a_result_t k4a_set_allocator(k4a_memory_allocate_cb_t allocate, k4a
  *
  * \relates k4a_device_t
  *
- * \return ::K4A_RESULT_SUCCEEDED if the device was opened successfully.
+ * \return ::K4A_RESULT_SUCCEEDED if the device was opened successfully. ::K4A_RESULT_FAILED if the device was
+ * not opened successfully.
  *
  * \remarks
  * If successful, k4a_device_open() will return a device handle in the device_handle parameter.
@@ -261,7 +264,8 @@ K4A_EXPORT k4a_wait_result_t k4a_device_get_capture(k4a_device_t device_handle,
  *
  * \returns
  * ::K4A_WAIT_RESULT_SUCCEEDED if a sample is returned. If a sample is not available before the timeout elapses, the
- * function will return ::K4A_WAIT_RESULT_TIMEOUT. All other failures will return ::K4A_WAIT_RESULT_FAILED.
+ * function will return ::K4A_WAIT_RESULT_TIMEOUT. If a device does not support an IMU, then
+ * ::K4A_WAIT_RESULT_UNSUPPORTED is returned. All other failures will return ::K4A_WAIT_RESULT_FAILED.
  *
  * \relates k4a_device_t
  *
@@ -1293,7 +1297,7 @@ K4A_EXPORT void k4a_device_stop_cameras(k4a_device_t device_handle);
  *
  * \returns
  * ::K4A_RESULT_SUCCEEDED is returned on success. ::K4A_RESULT_FAILED if the sensor is already running or a failure is
- * encountered
+ * encountered. If a device does not support an IMU, ::K4A_RESULT_UNSUPPORTED is returned.
  *
  * \relates k4a_device_t
  *
@@ -1433,7 +1437,8 @@ K4A_EXPORT k4a_result_t k4a_device_get_version(k4a_device_t device_handle, k4a_h
  * Location to store the color sensor's control default mode of /p command.
  *
  * \returns
- * ::K4A_RESULT_SUCCEEDED if the value was successfully returned, ::K4A_RESULT_FAILED if an error occurred
+ * ::K4A_RESULT_SUCCEEDED if the value was successfully returned, ::K4A_RESULT_FAILED if an error occurred.
+ * ::K4A_RESULT_UNSUPPORTED if the device does not support this operation.
  *
  * \relates k4a_device_t
  *
@@ -1472,7 +1477,8 @@ K4A_EXPORT k4a_result_t k4a_device_get_color_control_capabilities(k4a_device_t d
  * mode returned is ::K4A_COLOR_CONTROL_MODE_MANUAL for the current \p command.
  *
  * \returns
- * ::K4A_RESULT_SUCCEEDED if the value was successfully returned, ::K4A_RESULT_FAILED if an error occurred
+ * ::K4A_RESULT_SUCCEEDED if the value was successfully returned, ::K4A_RESULT_FAILED if an error occurred.
+ * ::K4A_RESULT_UNSUPPORTED if the device does not support this operation.
  *
  * \remarks
  * Each control command may be set to manual or automatic. See the definition of \ref k4a_color_control_command_t on
@@ -1517,7 +1523,8 @@ K4A_EXPORT k4a_result_t k4a_device_get_color_control(k4a_device_t device_handle,
  * is set to ::K4A_COLOR_CONTROL_MODE_MANUAL, and is otherwise ignored.
  *
  * \returns
- * ::K4A_RESULT_SUCCEEDED if the value was successfully set, ::K4A_RESULT_FAILED if an error occurred
+ * ::K4A_RESULT_SUCCEEDED if the value was successfully set, ::K4A_RESULT_FAILED if an error occurred.
+ * ::K4A_RESULT_UNSUPPORTED if the device does not support this operation.
  *
  * \remarks
  * Each control command may be set to manual or automatic. See the definition of \ref k4a_color_control_command_t on how
@@ -1637,6 +1644,7 @@ K4A_EXPORT k4a_result_t k4a_device_get_calibration(k4a_device_t device_handle,
  *
  * \returns
  * ::K4A_RESULT_SUCCEEDED if the connector status was successfully read.
+ * ::K4A_RESULT_UNSUPPORTED if the device does not support this operation.
  *
  * \relates k4a_device_t
  *
@@ -1728,7 +1736,7 @@ K4A_EXPORT k4a_result_t k4a_calibration_get_from_raw(char *raw_calibration,
  *
  * \returns
  * ::K4A_RESULT_SUCCEEDED if \p target_point3d_mm was successfully written. ::K4A_RESULT_FAILED if \p calibration
- * contained invalid transformation parameters.
+ * contained invalid transformation parameters. ::K4A_RESULT_UNSUPPORTED if the device does not support this operation.
  *
  * \remarks
  * This function is used to transform 3D points between depth and color camera coordinate systems. The function uses the
@@ -1783,7 +1791,7 @@ K4A_EXPORT k4a_result_t k4a_calibration_3d_to_3d(const k4a_calibration_t *calibr
  * ::K4A_RESULT_SUCCEEDED if \p target_point3d_mm was successfully written. ::K4A_RESULT_FAILED if \p calibration
  * contained invalid transformation parameters. If the function returns ::K4A_RESULT_SUCCEEDED, but \p valid is 0,
  * the transformation was computed, but the results in \p target_point3d_mm are outside of the range of valid
- * calibration and should be ignored.
+ * calibration and should be ignored. ::K4A_RESULT_UNSUPPORTED if the device does not support this operation.
  *
  * \remarks
  * This function applies the intrinsic calibration of \p source_camera to compute the 3D ray from the focal point of the
@@ -1840,7 +1848,7 @@ K4A_EXPORT k4a_result_t k4a_calibration_2d_to_3d(const k4a_calibration_t *calibr
  * ::K4A_RESULT_SUCCEEDED if \p target_point2d was successfully written. ::K4A_RESULT_FAILED if \p calibration
  * contained invalid transformation parameters. If the function returns ::K4A_RESULT_SUCCEEDED, but \p valid is 0,
  * the transformation was computed, but the results in \p target_point2d are outside of the range of valid calibration
- * and should be ignored.
+ * and should be ignored. ::K4A_RESULT_UNSUPPORTED if the device does not support this operation.
  *
  * \remarks
  * If \p target_camera is different from \p source_camera, \p source_point3d_mm is transformed to \p target_camera using
@@ -1900,7 +1908,7 @@ K4A_EXPORT k4a_result_t k4a_calibration_3d_to_2d(const k4a_calibration_t *calibr
  * ::K4A_RESULT_SUCCEEDED if \p target_point2d was successfully written. ::K4A_RESULT_FAILED if \p calibration
  * contained invalid transformation parameters. If the function returns ::K4A_RESULT_SUCCEEDED, but \p valid is 0,
  * the transformation was computed, but the results in \p target_point2d are outside of the range of valid calibration
- * and should be ignored.
+ * and should be ignored. ::K4A_RESULT_UNSUPPORTED if the device does not support this operation.
  *
  * \remarks
  * This function maps a pixel between the coordinate systems of the depth and color cameras. It is equivalent to calling
@@ -1957,7 +1965,7 @@ K4A_EXPORT k4a_result_t k4a_calibration_2d_to_2d(const k4a_calibration_t *calibr
  * ::K4A_RESULT_SUCCEEDED if \p target_point2d was successfully written. ::K4A_RESULT_FAILED if \p calibration
  * contained invalid transformation parameters. If the function returns ::K4A_RESULT_SUCCEEDED, but \p valid is 0,
  * the transformation was computed, but the results in \p target_point2d are outside of the range of valid calibration
- * and should be ignored.
+ * and should be ignored. ::K4A_RESULT_UNSUPPORTED if the device does not support this operation.
  *
  * \remarks
  * This function represents an alternative to k4a_calibration_2d_to_2d() if the number of pixels that need to be
@@ -2063,6 +2071,7 @@ K4A_EXPORT void k4a_transformation_destroy(k4a_transformation_t transformation_h
  *
  * \returns
  * ::K4A_RESULT_SUCCEEDED if \p transformed_depth_image was successfully written and ::K4A_RESULT_FAILED otherwise.
+ * ::K4A_RESULT_UNSUPPORTED if the device does not support this operation.
  *
  * \relates k4a_transformation_t
  *
@@ -2142,7 +2151,7 @@ K4A_EXPORT k4a_result_t k4a_transformation_depth_image_to_color_camera(k4a_trans
  *
  * \returns
  * ::K4A_RESULT_SUCCEEDED if \p transformed_depth_image and \p transformed_custom_image were successfully written and
- * ::K4A_RESULT_FAILED otherwise.
+ * ::K4A_RESULT_FAILED otherwise. ::K4A_RESULT_UNSUPPORTED if the device does not support this operation.
  *
  * \relates k4a_transformation_t
  *
@@ -2199,6 +2208,7 @@ k4a_transformation_depth_image_to_color_camera_custom(k4a_transformation_t trans
  *
  * \returns
  * ::K4A_RESULT_SUCCEEDED if \p transformed_color_image was successfully written and ::K4A_RESULT_FAILED otherwise.
+ * ::K4A_RESULT_UNSUPPORTED if the device does not support this operation.
  *
  * \relates k4a_transformation_t
  *
@@ -2251,6 +2261,7 @@ K4A_EXPORT k4a_result_t k4a_transformation_color_image_to_depth_camera(k4a_trans
  *
  * \returns
  * ::K4A_RESULT_SUCCEEDED if \p xyz_image was successfully written and ::K4A_RESULT_FAILED otherwise.
+ * ::K4A_RESULT_UNSUPPORTED if the device does not support this operation.
  *
  * \relates k4a_transformation_t
  *

--- a/include/k4a/k4atypes.h
+++ b/include/k4a/k4atypes.h
@@ -218,7 +218,7 @@ typedef enum
 {
     K4A_RESULT_SUCCEEDED = 0, /**< The result was successful */
     K4A_RESULT_FAILED,        /**< The result was a failure */
-    K4A_RESULT_UNSUPPORTED,   /**< The result was unsupported */
+    K4A_RESULT_UNSUPPORTED,   /**< The operation was unsupported */
 } k4a_result_t;
 
 /** Result code returned by Azure Kinect APIs.
@@ -234,7 +234,7 @@ typedef enum
     K4A_BUFFER_RESULT_SUCCEEDED = 0, /**< The result was successful */
     K4A_BUFFER_RESULT_FAILED,        /**< The result was a failure */
     K4A_BUFFER_RESULT_TOO_SMALL,     /**< The input buffer was too small */
-    K4A_BUFFER_RESULT_UNSUPPORTED,   /**< The result was unsupported */
+    K4A_BUFFER_RESULT_UNSUPPORTED,   /**< The operation was unsupported */
 } k4a_buffer_result_t;
 
 /** Result code returned by Azure Kinect APIs.
@@ -250,7 +250,7 @@ typedef enum
     K4A_WAIT_RESULT_SUCCEEDED = 0, /**< The result was successful */
     K4A_WAIT_RESULT_FAILED,        /**< The result was a failure */
     K4A_WAIT_RESULT_TIMEOUT,       /**< The operation timed out */
-    K4A_WAIT_RESULT_UNSUPPORTED,   /**< The result was unsupported */
+    K4A_WAIT_RESULT_UNSUPPORTED,   /**< The operation was unsupported */
 } k4a_wait_result_t;
 
 /** Verbosity levels of debug messaging


### PR DESCRIPTION
…UPPORTED for devices that choose not to support that operation.

<!-- 
     All pull requests should fix a Triage Approved issue. Put that issue # here:
     e.g. ## Fixes #300. 
-->
## Fixes #

### Description of the changes:
- Adding comments in docstrings that some functions may return K4A_*_UNSUPPORTED status.

<!-- Please check off the appropriate boxes with [x] before submitting your pull request -->
### Before submitting a Pull Request:
- [x] I reviewed [CONTRIBUTING.md](https://github.com/Microsoft/Azure-Kinect-Sensor-SDK/blob/develop/CONTRIBUTING.md)
- [x] I [built my changes](https://github.com/Microsoft/Azure-Kinect-Sensor-SDK/blob/develop/docs/building.md) locally
- [ ] I ran the [unit tests](https://github.com/Microsoft/Azure-Kinect-Sensor-SDK/blob/develop/docs/testing.md)
- [ ] I ran the [functional tests](https://github.com/Microsoft/Azure-Kinect-Sensor-SDK/blob/develop/docs/testing.md) with a device
- [ ] I ran the [performance tests](https://github.com/Microsoft/Azure-Kinect-Sensor-SDK/blob/develop/docs/testing.md) with a device

### I tested changes on: <!-- it's not required to have tested both, just indicate which one you tried -->
- [ ] Windows
- [ ] Linux


<!-- Specify how you tested your changes (i.e. manual/ad-hoc testing, automated testing, new automated tests added)-->

